### PR TITLE
fix(install): wire RTK hook non-interactively + export ~/.local/bin on PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -325,11 +325,18 @@ install_pxpipe() {
                 warn "could not create $USER_LOCAL_BIN"
                 return 0
             }
-            # When npm's prefix == USER_LOCAL_BIN (e.g. both are ~/.local),
-            # source and target resolve to the same path and `ln -sfn src dst`
-            # creates a self-referential symlink (dst -> dst), breaking `command -v`.
-            # In that case the binary is already where we want it — nothing to link.
-            if [[ "$(cd "$link_target" 2>/dev/null && pwd -P)" == "$(cd "$npm_pxpipe" 2>/dev/null && pwd -P)" ]]; then
+            # When npm's prefix resolves to USER_LOCAL_BIN (e.g. both are
+            # ~/.local), source and target are the SAME file and `ln -sfn src dst`
+            # would create a self-referential symlink (dst -> dst), breaking
+            # `command -v`. In that case the binary is already where we want it —
+            # nothing to link.
+            # NB: canonicalize via the PARENT dir — `cd` onto a file path fails,
+            # so `cd "$file" && pwd -P` yields "" for both sides and would skip
+            # the link even when the paths differ. Resolve dirname, keep basename.
+            local src_canon dst_canon
+            src_canon="$(cd "$(dirname "$npm_pxpipe")" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$(basename "$npm_pxpipe")")"
+            dst_canon="$(cd "$(dirname "$link_target")" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$(basename "$link_target")")"
+            if [[ -n "$src_canon" && "$src_canon" == "$dst_canon" ]]; then
                 : # same file — skip the symlink
             else
                 ln -sfn "$npm_pxpipe" "$link_target" \

--- a/install.sh
+++ b/install.sh
@@ -172,9 +172,13 @@ wire_shell_rc() {
         $0 == ENVIRON["TW_END"]   { skip = 0 }
     ' "$rc_file" > "$tmp" || { warn "could not rewrite $rc_file"; rm -f "$tmp"; return 1; }
 
-    # Append a fresh block.
+    # Append a fresh block. ~/.local/bin is where --with-rtk and --with-pxpipe
+    # drop their binaries; on many systems (notably macOS) it is not on PATH by
+    # default, so the block exports it — otherwise rtk/pxpipe install "succeeds"
+    # but every later `command -v rtk` returns nothing and the hooks/scrips break.
     {
         printf '%s\n' "$TW_RC_BEGIN"
+        printf '%s\n' 'case ":$PATH:" in *":'"$USER_LOCAL_BIN"':"*) : ;; *) export PATH="'"$USER_LOCAL_BIN"':$PATH" ;; esac'
         printf '%s\n' "tokenwar() { command bash \"\$HOME/.claude/skills/tokenwar/scripts/tokenwar.sh\" \"\$@\"; }"
         local provider_cli
         for provider_cli in "${WRAPPED_PROVIDER_CLIS[@]}"; do
@@ -241,12 +245,16 @@ install_plugins() {
     say "Plugins installed + enabled. Restart Claude Code to load them."
 }
 
-# Wire RTK's hook. `rtk init -g` is non-interactive and patches settings.json
-# itself. No-op (with a hint) when the binary isn't installed.
+# Wire RTK's hook. `rtk init -g --auto-patch --hook-only` is non-interactive
+# (the bare `rtk init -g` is interactive and blocks waiting for input, which
+# the previous `>/dev/null 2>&1` made invisible — the install silently exited
+# without writing the hook). --hook-only skips the RTK.md file; --auto-patch
+# patches ~/.claude/settings.json without prompting. No-op when the binary
+# isn't installed.
 wire_rtk_hook() {
     if command -v "$RTK_BIN" >/dev/null 2>&1; then
-        say "Wiring RTK hook (rtk init -g)"
-        "$RTK_BIN" init -g >/dev/null 2>&1 || warn "rtk init -g failed — run it manually"
+        say "Wiring RTK hook (rtk init -g --auto-patch --hook-only)"
+        "$RTK_BIN" init -g --auto-patch --hook-only >/dev/null 2>&1 || warn "rtk init -g --auto-patch --hook-only failed — run it manually"
     else
         warn "rtk binary not found — install it with --with-rtk (or run \`rtk init -g\` after installing the RTK CLI)."
     fi
@@ -295,16 +303,25 @@ install_pxpipe() {
     }
 
     if ! command -v "$PXPIPE_BIN" >/dev/null 2>&1; then
-        local npm_prefix npm_pxpipe
+        local npm_prefix npm_pxpipe link_target
         npm_prefix="$("$NPM_BIN" config get prefix 2>/dev/null || echo "")"
         npm_pxpipe="${npm_prefix}/bin/${PXPIPE_BIN}"
+        link_target="${USER_LOCAL_BIN}/${PXPIPE_BIN}"
         if [[ -n "$npm_prefix" && -x "$npm_pxpipe" ]]; then
             mkdir -p "$USER_LOCAL_BIN" || {
                 warn "could not create $USER_LOCAL_BIN"
                 return 0
             }
-            ln -sfn "$npm_pxpipe" "${USER_LOCAL_BIN}/${PXPIPE_BIN}" \
-                || warn "could not link pxpipe into $USER_LOCAL_BIN"
+            # When npm's prefix == USER_LOCAL_BIN (e.g. both are ~/.local),
+            # source and target resolve to the same path and `ln -sfn src dst`
+            # creates a self-referential symlink (dst -> dst), breaking `command -v`.
+            # In that case the binary is already where we want it — nothing to link.
+            if [[ "$(cd "$link_target" 2>/dev/null && pwd -P)" == "$(cd "$npm_pxpipe" 2>/dev/null && pwd -P)" ]]; then
+                : # same file — skip the symlink
+            else
+                ln -sfn "$npm_pxpipe" "$link_target" \
+                    || warn "could not link pxpipe into $USER_LOCAL_BIN"
+            fi
         fi
     fi
 

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -86,6 +86,25 @@ EOF
     grep -q "opencode()" "$HOME/.bashrc"
 }
 
+@test "shell-integration block exports ~/.local/bin on PATH" {
+    mock_claude_empty
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # ~/.local/bin is where --with-rtk and --with-pxpipe drop binaries; on macOS
+    # it is not on PATH by default, so the block must export it.
+    grep -q "export PATH=" "$HOME/.bashrc"
+    grep -q '\.local/bin' "$HOME/.bashrc"
+}
+
+@test "wire_rtk_hook uses the non-interactive --auto-patch --hook-only form" {
+    mock_claude_empty
+    run bash "$SCRIPT" --with-plugins
+    [ "$status" -eq 0 ]
+    # Must NOT use the interactive bare `init -g` (blocks waiting for input).
+    ! grep -qx "init -g" "$RTK_LOG"
+    grep -q "init -g --auto-patch --hook-only" "$RTK_LOG"
+}
+
 @test "--with-plugins re-enables a plugin clobbered by the first enable" {
     # Stateful mock: extern@mp is enabled until one of OUR plugins is enabled,
     # which flips it to disabled (the documented enable-clobber). install.sh must
@@ -183,6 +202,9 @@ EOF
     [ "$status" -eq 0 ]
     grep -q "install -g pxpipe-proxy@0.10.0" "$NPM_LOG"
     [ -x "$HOME/.local/bin/pxpipe" ]
+    # Regression: when npm prefix == USER_LOCAL_BIN, must NOT create a self-referential
+    # symlink (pxpipe -> pxpipe) which breaks `command -v pxpipe` / `[ -x ]` checks.
+    [[ ! -L "$HOME/.local/bin/pxpipe" || "$(readlink "$HOME/.local/bin/pxpipe")" != "$HOME/.local/bin/pxpipe" ]]
 }
 
 @test "--all installs plugins AND handles rtk and pxpipe" {

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -226,6 +226,42 @@ EOF
     [[ ! -L "$HOME/.local/bin/pxpipe" || "$(readlink "$HOME/.local/bin/pxpipe")" != "$HOME/.local/bin/pxpipe" ]]
 }
 
+@test "--with-pxpipe symlinks into ~/.local/bin when npm prefix differs" {
+    # Regression for the same-file guard: when npm's prefix is NOT ~/.local
+    # (the common case — Homebrew, a custom npm prefix…), pxpipe lands in
+    # <prefix>/bin and MUST be symlinked into ~/.local/bin. A guard that
+    # `cd`s onto the file path yields "" == "" for both sides and wrongly
+    # skips the link, leaving pxpipe unlinked. This test fails in that case.
+    mock_claude_empty
+    rm -f "$MOCK_BIN/pxpipe"
+    ln -s "$(command -v node)" "$MOCK_BIN/node"
+    local npm_prefix="$HOME/.npm-global"
+    cat > "$MOCK_BIN/npm" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1 \$2 \$3" == "config get prefix" ]]; then
+    echo "$npm_prefix"
+    exit 0
+fi
+echo "\$*" >> "$NPM_LOG"
+mkdir -p "$npm_prefix/bin"
+cat > "$npm_prefix/bin/pxpipe" <<'PXPIPE'
+#!/usr/bin/env bash
+[[ "\$1" == "--version" ]] && echo "0.10.0"
+PXPIPE
+chmod +x "$npm_prefix/bin/pxpipe"
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/npm"
+    PATH="$MOCK_BIN:/usr/bin:/bin"
+    run bash "$SCRIPT" --with-pxpipe
+    [ "$status" -eq 0 ]
+    grep -q "install -g pxpipe-proxy@0.10.0" "$NPM_LOG"
+    # The link must exist, be executable, be a symlink, and point at the npm bin.
+    [ -x "$HOME/.local/bin/pxpipe" ]
+    [ -L "$HOME/.local/bin/pxpipe" ]
+    [ "$(readlink "$HOME/.local/bin/pxpipe")" == "$npm_prefix/bin/pxpipe" ]
+}
+
 @test "--all installs plugins AND handles rtk and pxpipe" {
     mock_claude_empty
     ln -s "$(command -v node)" "$MOCK_BIN/node"


### PR DESCRIPTION
## Problem

`install.sh --all` reported success but left the RTK (and pxpipe) lanes silently broken: `tokenwar status` reported `rtk` as *not installed* even though the binary was physically present in `~/.local/bin/rtk`, and RTK compressed nothing because its `PreToolUse` hook was never written to `~/.claude/settings.json`.

Root cause — three distinct bugs in `install.sh`:

1. **`wire_shell_rc` never added `~/.local/bin` to `PATH`.** Both `--with-rtk` and `--with-pxpipe` drop binaries in `~/.local/bin`, but on macOS that directory is **not** on `PATH` by default. The install completed, but every later `command -v rtk` / `command -v pxpipe` returned nothing, so all tokenwar scripts (`status.sh`, `gain.sh`, `check.sh`) reported the tools as absent while the binaries were sitting on disk.

2. **`wire_rtk_hook` called `rtk init -g`, which is interactive** and blocks waiting for input. The redirection `>/dev/null 2>&1` hid the block, so the install exited silently *without* writing the `PreToolUse` Bash hook to `~/.claude/settings.json`. RTK was installed but never wired — it compressed nothing.

3. **`install_pxpipe` produced a self-referential symlink** when npm's global `prefix` resolved to the same directory as `USER_LOCAL_BIN` (both `~/.local`). `ln -sfn src dst` with `src == dst` created `pxpipe -> pxpipe`, a circular symlink that breaks `command -v pxpipe` and `[ -x ]`. (Pre-existing bug — also reproducible on `main`; surfaced by `tests/install.bats` test 11.)

## Fix

- `wire_shell_rc` now prepends `~/.local/bin` to `PATH` inside the tokenwar shell-integration block (idempotent guarded `case` — no duplicate entries on re-run).
- `wire_rtk_hook` switched to the non-interactive form `rtk init -g --auto-patch --hook-only` — patches `settings.json` without prompting, skips the `RTK.md` file.
- `install_pxpipe` detects the same-file case (via canonicalized `pwd -P` comparison) and skips the symlink — the binary is already where it belongs.

## Tests

Adds three regression tests in `tests/install.bats`:
- \`shell-integration block exports ~/.local/bin on PATH\`
- \`wire_rtk_hook uses the non-interactive --auto-patch --hook-only form\`
- \`--with-pxpipe\` regression: no self-referential symlink when \`npm prefix == USER_LOCAL_BIN\` (extends the pre-existing test 11, which previously failed on \`main\` and now passes).

Full run: \`bats tests/install.bats\` → **13/13 ok**.

The other pre-existing failures in \`tests/check.bats\` and \`tests/status.bats\` (10 on \`main\`) are environment-related (jq/node resolution) and unchanged by this PR — verified by stashing the patch and re-running on \`main\`. They are out of scope for this fix.

## Verification on a fresh macOS install

Reproduced the original failure, then confirmed the fix:
- Before: \`which rtk\` → not found; \`~/.claude/settings.json\` had no \`PreToolUse\` hook.
- After fix: \`which rtk\` → \`/Users/<user>/.local/bin/rtk 0.44.2\`; \`settings.json\` contains \`PreToolUse → Bash → \"rtk hook claude\"\`; \`/tokenwar status\` reports all 6 tools ✓ and provider Claude Code ✓.

## Scope

This PR only touches \`install.sh\` and \`tests/install.bats\`. No changes to runtime scripts, statusline, or config schema.