### PR TITLE
fix(tokenwar): repair rtk statusline badge and upgrade confirm loop

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -126,13 +126,18 @@ Two phases: detect, then confirm + apply.
 - For RTK: parses `cargo install --list` to detect path-installed dev builds; latest = `Cargo.toml` `version` on the tracked upstream branch (`git fetch` + `git show origin/<branch>:Cargo.toml`). Skips the public `cargo search rtk` registry — the public crate name belongs to a different project (Rust Type Kit) and gives wrong numbers.
 - Writes `~/.claude/tokenwar/upgrade-check.json` and exits `0` if all up-to-date, `2` if any update available.
 
-**Phase 2 — confirm + upgrade.** Read the cache, show a table `<tool>: <current> → <latest>` (skip tools already up-to-date), and use `AskUserQuestion` to confirm. On `Yes`:
+**Phase 2 — confirm + upgrade.** Read the cache, show a table `<tool>: <current> → <latest>` (skip tools already up-to-date), and use `AskUserQuestion` **once** to confirm. That single `AskUserQuestion` **is** the consent gate — do not ask again in any other form. On `Yes`, run the upgrade script exactly **once**:
 
-- Plugins: `claude plugin update <slug>` per tool with an update. Restart is required for the new version to load.
-- RTK (path-installed): `cd <repo_path> && git pull && cargo install --path . --force`. Discover `<repo_path>` from `cargo install --list` (line `rtk vX.Y.Z (<repo_path>):`).
-- RTK (registry-installed, rare): `cargo install rtk --force` — only if `cargo install --list` shows no path.
+```
+bash ~/.claude/skills/tokenwar/scripts/upgrade.sh --yes
+```
 
-After upgrade, re-run `check-updates.sh --force` then `status` so the version columns reflect the new state.
+- One Bash call handles **every** tool that needs an update (plugin scope detection, RTK path build, pxpipe npm) in a single pass — do **not** run `claude plugin update <slug>` per tool yourself, and do **not** run the script a second time. Per-tool calls and re-runs are what caused the old repeat-prompt loop.
+- `--yes` is required: without it the script prints its own `[y/N]` prompt, which finds no tty under the Bash tool, reads empty, and exits 0 with "Skipped" — nothing upgrades. Passing `--yes` suppresses only that redundant second prompt; consent is already captured by `AskUserQuestion`.
+- **Ordering matters (cache dependency):** Phase 1's `check-updates.sh --force` MUST have run first so the cache is fresh. `upgrade.sh` trusts `~/.claude/tokenwar/upgrade-check.json` verbatim; on a stale/empty cache it silently no-ops with "All tools up-to-date". Always: `check-updates.sh --force` → show table → `AskUserQuestion` → `upgrade.sh --yes`.
+- **On failure, stop — do not re-ask.** If `upgrade.sh` exits non-zero, surface its stderr to the user and stop. Never silently retry the flow.
+
+After a successful upgrade, re-run `check-updates.sh --force` then `status` so the version columns reflect the new state. Restart the CLI for plugin changes to load.
 
 **Passive surfacing.** `/tokenwar status` calls `check-updates.sh --quiet` at the end (uses the 24h cache, no network unless stale). If any update is available, status appends an `updates available (N):` block and a `→ Run /tokenwar upgrade to apply.` line. The user is never auto-upgraded — the trigger is always explicit. This matches the security principle of pinning versions: drift is reported, not silently applied.
 

--- a/scripts/tokenwar-statusline.sh
+++ b/scripts/tokenwar-statusline.sh
@@ -215,7 +215,7 @@ if command -v "$RTK_BIN" >/dev/null 2>&1; then
                 const cfg = JSON.parse(readFileSync(path, "utf8"));
                 const pre = (cfg.hooks && cfg.hooks.PreToolUse) || [];
                 return pre.some(h => (h.matcher||"") === "Bash"
-                    && (h.hooks||[]).some(x => (x.command||"").includes("rtk-rewrite")));
+                    && (h.hooks||[]).some(x => (x.command||"").includes("rtk hook")));
             } catch { return false; }
         };
         const wired = wiredIn(process.env.SETTINGS) || wiredIn(process.env.SETTINGS_LOCAL);

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -32,6 +32,11 @@ readonly PXPIPE_NPM_SPEC="${PXPIPE_NPM_PACKAGE}@${PXPIPE_NPM_VERSION}"
 readonly UPGRADE_CACHE_FILE="${HOME}/.claude/tokenwar/upgrade-check.json"
 readonly STATE_UPDATE="update-available"
 
+# Source of the interactive "Upgrade now? [y/N]" answer. The real controlling
+# terminal by default (so the prompt works even when stdin is a pipe), but
+# overridable via TW_TTY so the confirm path is testable without a live tty.
+readonly TTY_DEVICE="${TW_TTY:-/dev/tty}"
+
 readonly COL_GREEN=$'\033[32m'
 readonly COL_RED=$'\033[31m'
 readonly COL_YELLOW=$'\033[33m'
@@ -55,7 +60,7 @@ fail() { printf '%s %s\n' "${COL_RED}ERR${COL_RESET}" "$*" >&2; }
 # True only if /dev/tty can actually be opened (a controlling terminal exists).
 # The inner redirection's failure is swallowed by the group-level 2>/dev/null,
 # so probing never leaks "No such device or address".
-tty_readable() { { : </dev/tty; } 2>/dev/null; }
+tty_readable() { { : <"$TTY_DEVICE"; } 2>/dev/null; }
 
 # Which tools have an update? Echoes space-separated tool keys.
 # Reads the cache; with --all or no cache, returns every managed updater.
@@ -159,7 +164,7 @@ if ! $assume_yes; then
     reply=""
     if tty_readable; then
         printf "Upgrade now? [y/N] "
-        read -r reply </dev/tty 2>/dev/null || reply=""
+        read -r reply <"$TTY_DEVICE" 2>/dev/null || reply=""
     fi
     case "$reply" in
         y|Y|yes|YES) ;;

--- a/tests/upgrade-answers.bats
+++ b/tests/upgrade-answers.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Tests for upgrade.sh interactive confirm handling — the answer that the user
+# gives at the "Upgrade now? [y/N]" prompt must be honored exactly.
+#
+# Regression target: the old flow read the confirm from a hardcoded /dev/tty,
+# which is unavailable under the Bash tool / CI, so every interactive answer
+# collapsed to "empty → Skipped" and the caller re-asked in a loop. upgrade.sh
+# now reads the confirm from $TW_TTY (default /dev/tty), so tests can feed a
+# real answer through a file and assert it is respected.
+#
+# Cases covered: YES applies, NO declines, empty declines, an old→new version is
+# surfaced at the prompt, and the no-tty path still skips safely.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/upgrade.sh"
+    [ -x "$SCRIPT" ] || skip "upgrade.sh not executable"
+    export HOME="$(mktemp -d)"
+    mkdir -p "$HOME/.claude/tokenwar"
+    MOCK_BIN="$(mktemp -d)"
+    export ORIG_PATH="$PATH"
+    export PATH="$MOCK_BIN:$PATH"
+    export CLAUDE_LOG="$HOME/claude-calls.log"
+    export ANSWER_FILE="$HOME/answer.txt"
+}
+
+teardown() {
+    rm -rf "$HOME" "$MOCK_BIN"
+    export PATH="$ORIG_PATH"
+}
+
+# Mock claude: records args; reports caveman as user-scoped so upgrade_plugin runs.
+mock_claude() {
+    cat > "$MOCK_BIN/claude" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$CLAUDE_LOG"
+if [[ "\$1 \$2 \$3" == "plugin list --json" ]]; then
+cat <<'JSON'
+[{"id":"caveman@caveman","scope":"user","enabled":true}]
+JSON
+fi
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/claude"
+}
+
+# Cache flagging caveman as an available update from an OLD version to a NEW one.
+write_old_version_cache() {
+    cat > "$HOME/.claude/tokenwar/upgrade-check.json" <<'EOF'
+{"tools":{"context-mode":{"state":"up-to-date"},"claude-mem":{"state":"up-to-date"},"caveman":{"state":"update-available","current":"ec83e5bace4c","latest":"11ddc0c9813c"},"rtk":{"state":"up-to-date"}}}
+EOF
+}
+
+# Run the script with a canned interactive answer fed through $TW_TTY.
+run_with_answer() {
+    printf '%s\n' "$1" > "$ANSWER_FILE"
+    TW_TTY="$ANSWER_FILE" run bash "$SCRIPT" </dev/null
+}
+
+@test "prompt appears when an update is pending (old version surfaced)" {
+    mock_claude
+    write_old_version_cache
+    run_with_answer "n"
+    [[ "$output" == *"the following tools will be updated"* ]]
+    [[ "$output" == *"caveman"* ]]
+    [[ "$output" == *"Upgrade now?"* ]]
+}
+
+@test "answer YES → upgrade is applied" {
+    mock_claude
+    write_old_version_cache
+    run_with_answer "y"
+    [ "$status" -eq 0 ]
+    grep -q "plugin update caveman@caveman" "$CLAUDE_LOG"
+}
+
+@test "answer 'yes' (long form) → upgrade is applied" {
+    mock_claude
+    write_old_version_cache
+    run_with_answer "yes"
+    [ "$status" -eq 0 ]
+    grep -q "plugin update caveman@caveman" "$CLAUDE_LOG"
+}
+
+@test "answer NO → nothing is upgraded, exit 0, says Skipped" {
+    mock_claude
+    write_old_version_cache
+    run_with_answer "n"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipped"* ]]
+    [ ! -f "$CLAUDE_LOG" ] || ! grep -q "plugin update" "$CLAUDE_LOG"
+}
+
+@test "answer empty (bare Enter) → declines, nothing upgraded" {
+    mock_claude
+    write_old_version_cache
+    run_with_answer ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipped"* ]]
+    [ ! -f "$CLAUDE_LOG" ] || ! grep -q "plugin update" "$CLAUDE_LOG"
+}
+
+@test "answer garbage (not y/yes) → declines, nothing upgraded" {
+    mock_claude
+    write_old_version_cache
+    run_with_answer "maybe"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipped"* ]]
+    [ ! -f "$CLAUDE_LOG" ] || ! grep -q "plugin update" "$CLAUDE_LOG"
+}
+
+@test "no tty available at all → skips safely, exit 0, no /dev/tty leak" {
+    mock_claude
+    write_old_version_cache
+    # Point TW_TTY at a path that cannot be opened for reading.
+    TW_TTY="$HOME/does-not-exist/tty" run bash "$SCRIPT" </dev/null
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No interactive terminal"* ]]
+    [[ "$output" != *"No such device"* ]]
+    [ ! -f "$CLAUDE_LOG" ] || ! grep -q "plugin update" "$CLAUDE_LOG"
+}
+
+@test "--yes bypasses the prompt entirely (answer file never read)" {
+    mock_claude
+    write_old_version_cache
+    # A NO in the file must be ignored because --yes short-circuits the confirm.
+    printf 'n\n' > "$ANSWER_FILE"
+    TW_TTY="$ANSWER_FILE" run bash "$SCRIPT" --yes </dev/null
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Upgrade now?"* ]]
+    grep -q "plugin update caveman@caveman" "$CLAUDE_LOG"
+}


### PR DESCRIPTION
## What

Two tokenwar fixes surfaced while using the stack.

### 1. Statusline `[rtk -]` badge
Detection probed settings for a hook command containing `rtk-rewrite`, but rtk now wires its hook as `rtk hook claude`. Result: badge showed `-` despite rtk being installed and actively saving tokens. Now matches `rtk hook` → renders the real savings (e.g. `[rtk 8.5M]`).

### 2. `/tokenwar upgrade` confirm loop
Running upgrade re-asked the same `Upgrade now?` prompt repeatedly and never applied anything. Causes:
- SKILL.md Phase 2 told the model to run `claude plugin update` per tool (N permission prompts) or invoke `upgrade.sh` without `--yes`, whose own `[y/N]` prompt reads `/dev/tty` — absent under the Bash tool — so it always exited 0 with "Skipped", triggering a retry.
- Phase 2 rewritten: a single `AskUserQuestion` is the consent gate, then `upgrade.sh --yes` runs exactly once (loops every pending tool in one pass). Added explicit cache-ordering note and a "stop on non-zero, do not re-ask" guard.

### Testability seam
`upgrade.sh` reads the interactive confirm from `$TW_TTY` (default `/dev/tty`) instead of a hardcoded path, so the answer path is testable without a live terminal.

## Test verification (RED → GREEN)

New `tests/upgrade-answers.bats` covers the full answer matrix: prompt appears for a pending old→new version, `y`/`yes` apply, `n`/empty/garbage decline, no-tty skips safely, `--yes` bypasses the prompt.

**RED** (before the `$TW_TTY` seam) — interactive answers unreachable:
```
not ok 1 prompt appears when an update is pending (old version surfaced)
not ok 2 answer YES → upgrade is applied
not ok 3 answer 'yes' (long form) → upgrade is applied
ok 4..8  (decline paths already green — do not depend on the seam)
```

**GREEN** (after the seam):
```
ok 1..8   tests/upgrade-answers.bats
ok 1..7   tests/upgrade.bats  (non-regression)
full suite: 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
