### PR TITLE
feat: tokenwar enable|disable <tool> toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Inside Claude Code (`/tokenwar <subcommand>`) or standalone (`bash ~/.claude/ski
 | `/tokenwar check` | Conflict detector — verifies the 6 tools stack additively |
 | `/tokenwar test` | End-to-end ping: is each tool actually working? |
 | `/tokenwar doctor` | Full pipeline: status → test → check → gain |
+| `/tokenwar disable <tool>` | Turn off one plugin (`context-mode`/`claude-mem`/`caveman`/`ponytail`) without uninstalling it |
+| `/tokenwar enable <tool>` | Turn a disabled plugin back on |
 
 ## Status in every CLI (Claude, Codex, Gemini, Kimi, opencode)
 
@@ -145,6 +147,8 @@ tokenwar status     # state of the 6 tools + providers
 tokenwar gain       # token savings + monthly $ value
 tokenwar upgrade    # bump managed tools (asks confirmation)
 tokenwar doctor     # status → check → gain
+tokenwar disable context-mode   # turn off one plugin without uninstalling it
+tokenwar enable  context-mode   # turn it back on
 ```
 
 > The banner is silent for non-interactive launches (`codex exec`,

--- a/SKILL.md
+++ b/SKILL.md
@@ -74,6 +74,8 @@ context, never the screen. So tokenwar surfaces the stack differently per CLI:
 /tokenwar gain       # per-tool + global token-savings report
 /tokenwar check      # conflict detector — verifies the 6 tools are complementary
 /tokenwar doctor     # full pipeline: status → test → check → gain
+/tokenwar disable X  # turn off one plugin (context-mode|claude-mem|caveman|ponytail)
+/tokenwar enable X   # turn a disabled plugin back on
 ```
 
 ## Routing
@@ -250,6 +252,16 @@ Verdict: <ALL GREEN | ATTENTION NEEDED — see <section>>
 ```
 
 Stop at the first `FAIL` if the user typed `/tokenwar doctor --strict`; otherwise run all four sections regardless.
+
+## Subcommand: disable / enable
+
+Let a user turn ONE managed tool off (or back on) without uninstalling it. Run:
+
+```
+bash ~/.claude/skills/tokenwar/scripts/toggle.sh <enable|disable> <tool>
+```
+
+Only the four Claude Code plugins are toggleable — `context-mode`, `claude-mem`, `caveman`, `ponytail` — driven by the native `claude plugin enable|disable <slug>` (reversible, keeps the plugin installed). `rtk` and `pxpipe` are standalone binaries, not plugins: the script refuses them (exit 3) and prints the correct per-tool mechanism instead. Unknown tool/action exits 2. Remind the user to restart the CLI for the change to take effect. This is the safe alternative to hand-editing `enabledPlugins` in `~/.claude/settings.json`.
 
 ---
 

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# tokenwar enable|disable — let a user turn an individual managed tool on or off
+# WITHOUT uninstalling it or hand-editing ~/.claude/settings.json.
+#
+#   tokenwar disable context-mode   # stop loading it, keep it installed
+#   tokenwar enable  context-mode   # turn it back on
+#
+# The four Claude Code plugins share one native, reversible mechanism
+# (`claude plugin enable|disable <slug>`), so we drive that directly. rtk and
+# pxpipe are standalone binaries, not plugins — there is no plugin toggle for
+# them, so we point the user at the correct per-tool mechanism instead of doing
+# risky settings.json / npm surgery here.
+
+set -euo pipefail
+
+readonly CLAUDE_BIN="claude"
+
+# Plugin tools: friendly name → marketplace slug (must match status.sh).
+readonly SLUG_CONTEXT_MODE="context-mode@context-mode"
+readonly SLUG_CLAUDE_MEM="claude-mem@thedotmack"
+readonly SLUG_CAVEMAN="caveman@caveman"
+readonly SLUG_PONYTAIL="ponytail@ponytail"
+
+# Non-plugin tools we recognise but cannot toggle via `claude plugin`.
+readonly NON_PLUGIN_TOOLS=" rtk pxpipe "
+
+readonly ACTION_ENABLE="enable"
+readonly ACTION_DISABLE="disable"
+
+readonly EXIT_USAGE=2
+readonly EXIT_UNSUPPORTED=3
+
+readonly COL_GREEN=$'\033[32m'
+readonly COL_YELLOW=$'\033[33m'
+readonly COL_RESET=$'\033[0m'
+
+usage() {
+    cat <<EOF
+tokenwar ${ACTION_ENABLE}|${ACTION_DISABLE} <tool>
+
+Turn an individual managed tool on or off without uninstalling it.
+
+Toggleable plugins:
+  context-mode   claude-mem   caveman   ponytail
+
+Examples:
+  tokenwar ${ACTION_DISABLE} context-mode
+  tokenwar ${ACTION_ENABLE}  context-mode
+
+Note: rtk and pxpipe are standalone binaries, not Claude Code plugins, so they
+are not toggled here — see the message printed when you name them.
+EOF
+}
+
+# Map a friendly tool name to its plugin slug. Empty output = not a plugin.
+slug_for() {
+    case "$1" in
+        context-mode) printf '%s' "$SLUG_CONTEXT_MODE" ;;
+        claude-mem)   printf '%s' "$SLUG_CLAUDE_MEM" ;;
+        caveman)      printf '%s' "$SLUG_CAVEMAN" ;;
+        ponytail)     printf '%s' "$SLUG_PONYTAIL" ;;
+        *)            printf '' ;;
+    esac
+}
+
+action="${1:-}"
+tool="${2:-}"
+
+case "$action" in
+    "$ACTION_ENABLE"|"$ACTION_DISABLE") ;;
+    -h|--help|help) usage; exit 0 ;;
+    *) echo "unknown action: ${action:-<none>}" >&2; echo "" >&2; usage >&2; exit "$EXIT_USAGE" ;;
+esac
+
+if [[ -z "$tool" ]]; then
+    echo "missing tool name" >&2; echo "" >&2; usage >&2; exit "$EXIT_USAGE"
+fi
+
+# rtk / pxpipe are not plugins — refuse with an actionable pointer.
+if [[ "$NON_PLUGIN_TOOLS" == *" $tool "* ]]; then
+    case "$tool" in
+        rtk)
+            echo "${COL_YELLOW}rtk is a standalone binary, not a Claude Code plugin.${COL_RESET}" >&2
+            echo "  enable : rtk init -g --auto-patch --hook-only" >&2
+            echo "  disable: remove the 'rtk hook claude' PreToolUse hook from ~/.claude/settings.json" >&2
+            ;;
+        pxpipe)
+            echo "${COL_YELLOW}pxpipe is a standalone proxy binary, not a Claude Code plugin.${COL_RESET}" >&2
+            echo "  enable : install it (tokenwar install --with-pxpipe)" >&2
+            echo "  disable: npm rm -g pxpipe-proxy" >&2
+            ;;
+    esac
+    exit "$EXIT_UNSUPPORTED"
+fi
+
+slug="$(slug_for "$tool")"
+if [[ -z "$slug" ]]; then
+    echo "unknown tool: $tool" >&2; echo "" >&2; usage >&2; exit "$EXIT_USAGE"
+fi
+
+if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
+    echo "claude CLI not found — cannot ${action} $tool" >&2
+    exit 1
+fi
+
+if ! "$CLAUDE_BIN" plugin "$action" "$slug" >/dev/null 2>&1; then
+    echo "claude plugin ${action} ${slug} failed" >&2
+    exit 1
+fi
+
+if [[ "$action" == "$ACTION_DISABLE" ]]; then
+    echo "${COL_GREEN}✓${COL_RESET} disabled ${tool} (${slug}) — still installed, just not loaded"
+else
+    echo "${COL_GREEN}✓${COL_RESET} enabled ${tool} (${slug})"
+fi
+echo "  Restart Claude Code for the change to take effect."

--- a/scripts/tokenwar.sh
+++ b/scripts/tokenwar.sh
@@ -11,6 +11,8 @@
 #   tokenwar upgrade    # bump managed tools (asks confirmation)
 #   tokenwar updates    # show available updates (throttled cache)
 #   tokenwar doctor     # status → check → gain
+#   tokenwar disable X  # turn off one tool without uninstalling it
+#   tokenwar enable  X  # turn it back on
 #
 # install.sh wires a `tokenwar` shell function pointing here, so users type
 # `tokenwar status` directly.
@@ -33,6 +35,8 @@ Commands:
   upgrade    bump managed tools to latest (asks confirmation)
   updates    show available updates (throttled 24h cache)
   doctor     full pipeline: status -> check -> gain
+  disable X  turn off one tool (context-mode|claude-mem|caveman|ponytail) without uninstalling it
+  enable X   turn one tool back on
   help       this message
 EOF
 }
@@ -46,6 +50,7 @@ case "$cmd" in
     check)   exec bash "${SCRIPT_DIR}/check.sh" "$@" ;;
     upgrade) exec bash "${SCRIPT_DIR}/upgrade.sh" "$@" ;;
     updates) exec bash "${SCRIPT_DIR}/check-updates.sh" "$@" ;;
+    enable|disable) exec bash "${SCRIPT_DIR}/toggle.sh" "$cmd" "$@" ;;
     doctor)
         bash "${SCRIPT_DIR}/status.sh" || true
         bash "${SCRIPT_DIR}/check.sh"  || true

--- a/tests/toggle.bats
+++ b/tests/toggle.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# Tests for toggle.sh — `tokenwar enable|disable <tool>`.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/toggle.sh"
+    [ -x "$SCRIPT" ] || skip "toggle.sh not executable"
+
+    MOCK_BIN="$(mktemp -d)"
+    export ORIG_PATH="$PATH"
+    export PATH="$MOCK_BIN:$PATH"
+    # Record what `claude plugin ...` was called with.
+    export CLAUDE_CALL_LOG="$MOCK_BIN/claude-calls.log"
+}
+
+teardown() {
+    rm -rf "$MOCK_BIN"
+    export PATH="$ORIG_PATH"
+}
+
+# Mock a `claude` CLI whose `plugin enable|disable` succeeds and logs its args.
+mock_claude_ok() {
+    cat > "$MOCK_BIN/claude" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$CLAUDE_CALL_LOG"
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/claude"
+}
+
+# Mock a `claude` whose `plugin` verb fails.
+mock_claude_fail() {
+    cat > "$MOCK_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$MOCK_BIN/claude"
+}
+
+@test "disable context-mode calls claude plugin disable with the right slug" {
+    mock_claude_ok
+    run bash "$SCRIPT" disable context-mode
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"disabled context-mode"* ]]
+    grep -qF "plugin disable context-mode@context-mode" "$CLAUDE_CALL_LOG"
+}
+
+@test "enable claude-mem calls claude plugin enable with the right slug" {
+    mock_claude_ok
+    run bash "$SCRIPT" enable claude-mem
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"enabled claude-mem"* ]]
+    grep -qF "plugin enable claude-mem@thedotmack" "$CLAUDE_CALL_LOG"
+}
+
+@test "every plugin tool maps to a slug" {
+    mock_claude_ok
+    for tool in context-mode claude-mem caveman ponytail; do
+        run bash "$SCRIPT" disable "$tool"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "rtk is refused as a non-plugin with a pointer (exit 3)" {
+    mock_claude_ok
+    run bash "$SCRIPT" disable rtk
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"standalone binary"* ]]
+    [ ! -f "$CLAUDE_CALL_LOG" ]   # never touched claude
+}
+
+@test "pxpipe is refused as a non-plugin with a pointer (exit 3)" {
+    mock_claude_ok
+    run bash "$SCRIPT" disable pxpipe
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"proxy binary"* ]]
+}
+
+@test "unknown tool exits 2 with usage" {
+    mock_claude_ok
+    run bash "$SCRIPT" disable bogus
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown tool"* ]]
+}
+
+@test "unknown action exits 2" {
+    run bash "$SCRIPT" frobnicate context-mode
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown action"* ]]
+}
+
+@test "missing tool name exits 2" {
+    run bash "$SCRIPT" disable
+    [ "$status" -eq 2 ]
+}
+
+@test "propagates a claude plugin failure (exit 1)" {
+    mock_claude_fail
+    run bash "$SCRIPT" disable context-mode
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed"* ]]
+}
+
+@test "dispatcher routes disable to toggle.sh" {
+    mock_claude_ok
+    run bash "$BATS_TEST_DIRNAME/../scripts/tokenwar.sh" disable context-mode
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"disabled context-mode"* ]]
+}


### PR DESCRIPTION
## What

Adds `tokenwar enable <tool>` / `tokenwar disable <tool>` so a user can turn one managed plugin off (or back on) **without uninstalling it** or hand-editing `enabledPlugins` in `~/.claude/settings.json`.

Motivation: a user wanted context-mode off for themselves only. Until now the only route was manual settings.json surgery.

## How

- **`scripts/toggle.sh`** (new): drives the native `claude plugin enable|disable <slug>` for the 4 Claude Code plugins — `context-mode`, `claude-mem`, `caveman`, `ponytail`. Reversible, keeps the plugin installed.
- `rtk` / `pxpipe` are standalone binaries, not plugins → refused with **exit 3** and a pointer to their own mechanism (no risky settings/npm surgery).
- Unknown tool/action → **exit 2**; a failed `claude plugin` call propagates **exit 1**.
- `tokenwar.sh` dispatcher routes the new `enable`/`disable` verbs.
- Docs updated in the SAME PR: README command table + quick-ref, SKILL usage block + a `disable / enable` routing section.

## Test verification (RED → GREEN)

New `tests/toggle.bats` (10 cases: slug mapping for all 4 plugins, non-plugin refusal for rtk/pxpipe, unknown tool/action, missing arg, `claude plugin` failure propagation, dispatcher routing).

**RED** — on unmodified `main` with only the test + toggle.sh present, the dispatcher-routing case fails (dispatcher answers `unknown command`, exit 2):
```
not ok 10 dispatcher routes disable to toggle.sh
#   `[ "$status" -eq 0 ]' failed
```

**GREEN** — with the dispatcher wiring in place, full suite:
```
104 tests, 0 failures   (94 pre-existing + 10 new)
shellcheck -S warning scripts/*.sh scripts/lib/*.sh  → clean
```

**Live** — exercised the real `claude plugin` CLI end-to-end:
```
$ tokenwar enable  context-mode   # settings.json: false → true, exit 0
$ tokenwar disable context-mode   # settings.json: true → false, exit 0
$ tokenwar disable rtk            # exit 3, prints per-tool pointer, never touches claude
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)