### PR TITLE
fix(status): complete plugin detection — CLI-first + on-disk fallback + tests (follow-up to #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,15 @@ Add to `~/.bashrc` to auto-restore before each Claude Code launch:
 alias claude='bash ~/.claude/skills/tokenwar/scripts/restore-settings.sh && command claude'
 ```
 
+## Plugin-state detection (robust on any host)
+
+`tokenwar status` reads the 4 Claude Code plugins' state from `claude plugin list --json` — the authoritative source (installed **and** enabled state in one shot). On hosts where that command returns nothing (an older `claude` CLI without the subcommand, or `claude` not on `PATH` in the shell running tokenwar), status falls back to on-disk config instead of reporting every plugin as *not installed*:
+
+- `~/.claude/plugins/installed_plugins.json` → what is installed,
+- `enabledPlugins` OR-merged from `settings.json` **and** `settings.local.json` → the enabled/disabled bit (Claude Code merges both at runtime).
+
+An installed plugin absent from `enabledPlugins` is treated as enabled (Claude default); an explicit `false` stays `installed-disabled` — so `tokenwar disable <tool>` is always reflected correctly. Override the config dir with `CLAUDE_CONFIG_DIR`.
+
 ## Tests + CI
 
 ```bash

--- a/scripts/lib/plugins.sh
+++ b/scripts/lib/plugins.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Shared Claude Code plugin-state loader.
+#
+# Primary source of truth is `claude plugin list --json` — it reports what is
+# installed AND each plugin's `enabled` bit in one shot, and is what the test
+# harness mocks. When the CLI yields no usable JSON array (old CLI without the
+# subcommand, or `claude` not on PATH), fall back to on-disk config:
+#   - installed_plugins.json  → what is installed
+#   - enabledPlugins OR-merged from settings.json AND settings.local.json
+#     → the enabled/disabled bit (Claude Code merges both files at runtime, so a
+#     plugin enabled only in the local file must not read as disabled).
+# An installed plugin absent from enabledPlugins is enabled by default (Claude
+# semantics); an explicit `false` stays disabled — we never coerce to enabled,
+# which would hide `installed-disabled`.
+#
+# Config dir is overridable via CLAUDE_CONFIG_DIR (tests, relocated ~/.claude).
+# The claude binary is overridable via TW_CLAUDE_BIN (defaults to `claude`).
+
+# tw_load_plugin_list — echo a JSON array of {id, enabled, version}.
+tw_load_plugin_list() {
+    local claude_bin="${TW_CLAUDE_BIN:-claude}"
+
+    # 1. Primary: the claude CLI (authoritative + mockable).
+    local cli_out
+    cli_out="$("$claude_bin" plugin list --json 2>/dev/null)"
+    if [[ -n "$cli_out" ]] \
+        && node -e "const a=JSON.parse(process.argv[1]);process.exit(Array.isArray(a)&&a.length?0:1)" "$cli_out" 2>/dev/null; then
+        printf '%s' "$cli_out"
+        return
+    fi
+
+    # 2. Fallback: derive from on-disk config when the CLI cannot answer.
+    local config_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+    local installed_file="${config_dir}/plugins/installed_plugins.json"
+    if [[ ! -f "$installed_file" ]]; then
+        printf '[]'
+        return
+    fi
+
+    INSTALLED_FILE="$installed_file" \
+    SETTINGS_FILE="${config_dir}/settings.json" \
+    SETTINGS_LOCAL_FILE="${config_dir}/settings.local.json" \
+    node --input-type=module -e '
+        import { readFileSync } from "node:fs";
+        const read = f => { try { return JSON.parse(readFileSync(f, "utf8")); } catch { return null; } };
+        const installed = read(process.env.INSTALLED_FILE) || {};
+        const enabledMap = {
+            ...((read(process.env.SETTINGS_FILE) || {}).enabledPlugins || {}),
+            ...((read(process.env.SETTINGS_LOCAL_FILE) || {}).enabledPlugins || {}),
+        };
+        const out = [];
+        for (const [id, installs] of Object.entries(installed.plugins || {})) {
+            if (!Array.isArray(installs) || installs.length === 0) continue;
+            const enabled = id in enabledMap ? Boolean(enabledMap[id]) : true;
+            out.push({ id, enabled, version: installs[0].version || "unknown" });
+        }
+        console.log(JSON.stringify(out));
+    ' 2>/dev/null || printf '[]'
+}

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -15,6 +15,8 @@ readonly SCRIPT_DIR
 
 # shellcheck source=lib/providers.sh
 source "${SCRIPT_DIR}/lib/providers.sh"
+# shellcheck source=lib/plugins.sh
+source "${SCRIPT_DIR}/lib/plugins.sh"
 
 readonly STATUS_OK="OK"
 readonly STATUS_DISABLED="installed-disabled"
@@ -31,32 +33,12 @@ readonly MEM_BIN="claude-mem"
 readonly CLAUDE_BIN="claude"
 readonly PXPIPE_BIN="pxpipe"
 
-# Cache plugin list from installed_plugins.json to avoid repeated file reads.
+# Cache the plugin list. CLI-first with on-disk fallback lives in lib/plugins.sh
+# (tw_load_plugin_list) so every script that needs plugin state shares one path.
 PLUGIN_LIST_JSON=""
 load_plugin_list() {
-    if [[ -z "$PLUGIN_LIST_JSON" ]]; then
-        local plugins_file="${HOME}/.claude/plugins/installed_plugins.json"
-        if [[ -f "$plugins_file" ]]; then
-            PLUGIN_LIST_JSON=$(node --input-type=module -e "
-                import { readFileSync } from 'node:fs';
-                const data = JSON.parse(readFileSync('${plugins_file}', 'utf8'));
-                const pluginList = [];
-                for (const [id, installs] of Object.entries(data.plugins || {})) {
-                    if (installs && installs.length > 0) {
-                        const install = installs[0];
-                        pluginList.push({
-                            id: id,
-                            enabled: true,
-                            version: install.version || 'unknown'
-                        });
-                    }
-                }
-                console.log(JSON.stringify(pluginList));
-            " 2>/dev/null || echo '[]')
-        else
-            PLUGIN_LIST_JSON='[]'
-        fi
-    fi
+    [[ -n "$PLUGIN_LIST_JSON" ]] && return
+    PLUGIN_LIST_JSON="$(TW_CLAUDE_BIN="$CLAUDE_BIN" tw_load_plugin_list)"
 }
 
 readonly COL_GREEN=$'\033[32m'

--- a/tests/status-fallback.bats
+++ b/tests/status-fallback.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# Tests for status.sh's fallback path (lib/plugins.sh) — when `claude plugin list
+# --json` yields nothing, the plugin list is derived from on-disk config:
+# installed_plugins.json for installed + settings.json/settings.local.json →
+# enabledPlugins for the enabled bit. Regression guard for #8/#10: an explicitly
+# disabled plugin must NOT report OK (the hardcoded-`enabled:true` version did).
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/status.sh"
+    [ -x "$SCRIPT" ] || skip "status.sh not executable"
+
+    MOCK_BIN="$(mktemp -d)"
+    export ORIG_PATH="$PATH"
+    export PATH="$MOCK_BIN:$PATH"
+
+    # Injectable fake ~/.claude for the fallback to read.
+    export CLAUDE_CONFIG_DIR="$(mktemp -d)"
+    mkdir -p "$CLAUDE_CONFIG_DIR/plugins"
+
+    # claude CLI present but returns NOTHING for `plugin list --json` → forces the
+    # fallback while proving we distinguish "empty CLI" from "no CLI".
+    cat > "$MOCK_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/claude"
+
+    # rtk + pxpipe healthy so only plugin state varies.
+    cat > "$MOCK_BIN/rtk" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "gain" ]] && echo "Tokens saved: 1M"
+[[ "$1" == "--version" ]] && echo "rtk 0.30.1"
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/rtk"
+    cat > "$MOCK_BIN/pxpipe" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "--version" ]] && echo "0.10.0"
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/pxpipe"
+}
+
+teardown() {
+    rm -rf "$MOCK_BIN" "$CLAUDE_CONFIG_DIR"
+    export PATH="$ORIG_PATH"
+}
+
+write_installed()      { printf '%s\n' "$1" > "$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json"; }
+write_settings()       { printf '%s\n' "$1" > "$CLAUDE_CONFIG_DIR/settings.json"; }
+write_settings_local() { printf '%s\n' "$1" > "$CLAUDE_CONFIG_DIR/settings.local.json"; }
+
+@test "fallback: an explicitly disabled plugin reports installed-disabled (not OK)" {
+    write_installed '{"plugins":{"context-mode@context-mode":[{"version":"1.0.107"}]}}'
+    write_settings  '{"enabledPlugins":{"context-mode@context-mode":false}}'
+    run bash "$SCRIPT"
+    [[ "$output" == *"context-mode"*"installed-disabled"* ]]
+}
+
+@test "fallback: an explicitly enabled plugin reports OK" {
+    write_installed '{"plugins":{"context-mode@context-mode":[{"version":"1.0.107"}]}}'
+    write_settings  '{"enabledPlugins":{"context-mode@context-mode":true}}'
+    run bash "$SCRIPT"
+    [[ "$output" == *"context-mode"*"1.0.107"*"OK"* ]]
+}
+
+@test "fallback: installed but absent from enabledPlugins defaults to enabled (OK)" {
+    write_installed '{"plugins":{"context-mode@context-mode":[{"version":"1.0.107"}]}}'
+    write_settings  '{"enabledPlugins":{}}'
+    run bash "$SCRIPT"
+    [[ "$output" == *"context-mode"*"OK"* ]]
+}
+
+@test "fallback: a plugin not in installed_plugins reports not-installed" {
+    write_installed '{"plugins":{}}'
+    write_settings  '{"enabledPlugins":{}}'
+    run bash "$SCRIPT"
+    [[ "$output" == *"context-mode"*"not-installed"* ]]
+}
+
+@test "fallback: malformed installed_plugins.json degrades to not-installed, no crash" {
+    write_installed 'this is not json'
+    write_settings  '{"enabledPlugins":{}}'
+    run bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"context-mode"*"not-installed"* ]]
+}
+
+@test "fallback: enabled only in settings.local.json still reports OK (OR-merge)" {
+    # Regression: Claude Code merges settings.json + settings.local.json at
+    # runtime, so a plugin enabled solely in the local file must NOT read disabled.
+    write_installed       '{"plugins":{"context-mode@context-mode":[{"version":"1.0.107"}]}}'
+    write_settings        '{"enabledPlugins":{"context-mode@context-mode":false}}'
+    write_settings_local  '{"enabledPlugins":{"context-mode@context-mode":true}}'
+    run bash "$SCRIPT"
+    [[ "$output" == *"context-mode"*"OK"* ]]
+    [[ "$output" != *"context-mode"*"installed-disabled"* ]]
+}


### PR DESCRIPTION
Follow-up to #8 by @Sasu-Spidr (now merged). #8 landed the right instinct — read on-disk config when the CLI can't answer — for a real symptom: on some hosts `claude plugin list --json` returns empty and every plugin was mis-reported as *not installed*. This PR completes that work so the whole thing is correct and covered by tests. Refs #10.

## What #8 still needed
- It hardcoded `enabled: true`, which hid `installed-disabled` and silently broke the merged `tokenwar enable|disable <tool>` feature (disable a plugin → status still says OK).
- It read a file directly, bypassing the `claude`-binary mocks → 4/8 `status.bats` cases went red.

## This PR
- **Shared `lib/plugins.sh::tw_load_plugin_list`** — one code path for every script that needs plugin state.
- **Primary source stays `claude plugin list --json`** (installed + enabled in one shot, and what the tests mock) → the 8 `status.bats` cases pass again.
- **Distinguishes an empty CLI from no CLI** — only falls back when the CLI returns no usable JSON array; a valid `[]` is respected.
- **Fallback keeps @Sasu-Spidr's `installed_plugins.json` read for *installed***, and adds the enabled bit from `enabledPlugins` **OR-merged across `settings.json` and `settings.local.json`** (Claude Code merges both at runtime). An explicit `false` stays disabled — never coerced to enabled.
- **`CLAUDE_CONFIG_DIR` injectable** for tests / relocated `~/.claude`; malformed JSON degrades safely.
- **README** documents the CLI-first + fallback behaviour.

## Test verification (RED → GREEN)
New `tests/status-fallback.bats` — 6 fixture cases: disabled, enabled, implicit-enabled default, not-installed, malformed, and the `settings.local.json` OR-merge.

**RED** on #8's merged (hardcoded-`true`) version — current `main`:
```
not ok 2 exit 1 when only ponytail is missing
not ok 4 exit 1 when a plugin is missing
not ok 5 exit 1 when a plugin is installed-disabled
not ok 8 provider-only update does not advertise managed upgrade command
```

**GREEN** with this PR:
```
tests/status.bats          8/8
tests/status-fallback.bats 6/6
full suite                 110/110
shellcheck -S warning      clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)