### PR TITLE
Feature: Ajouter un mode sortie `--json` à status, gain et check

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -31,6 +31,14 @@ readonly COL_YELLOW=$'\033[33m'
 readonly COL_DIM=$'\033[2m'
 readonly COL_RESET=$'\033[0m'
 
+json_mode=false
+for arg in "$@"; do
+    case "$arg" in
+        --json) json_mode=true ;;
+        *) echo "unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
 emit() {
     local rule="$1" result="$2" evidence="$3"
     local color
@@ -161,11 +169,10 @@ check_r4() {
     fi
 }
 
-echo ""
-echo "# /tokenwar check"
-echo ""
-
+# === gather results (shared) ===
 declare -A results
+declare -A evidences
+declare -A labels
 for rule_id in R1 R2 R3 R4 R5; do
     case "$rule_id" in
         R1) raw=$(check_r1); label="R1 bash double-hook" ;;
@@ -177,7 +184,8 @@ for rule_id in R1 R2 R3 R4 R5; do
     result="${raw%%|*}"
     evidence="${raw#*|}"
     results[$rule_id]="$result"
-    emit "$label" "$result" "$evidence"
+    evidences[$rule_id]="$evidence"
+    labels[$rule_id]="$label"
 done
 
 # verdict
@@ -188,6 +196,40 @@ for r in "${results[@]}"; do
         "$RES_FAIL") verdict="CONFLICT";       exit_code=1 ;;
         "$RES_WARN") [[ "$verdict" != "CONFLICT" ]] && verdict="DEGRADED"; exit_code=1 ;;
     esac
+done
+
+if $json_mode; then
+    # Build JSON via node — serialize inline blocks (results already computed)
+    R1_RESULT="${results[R1]}" R1_EVIDENCE="${evidences[R1]}" R1_LABEL="${labels[R1]}" \
+    R2_RESULT="${results[R2]}" R2_EVIDENCE="${evidences[R2]}" R2_LABEL="${labels[R2]}" \
+    R3_RESULT="${results[R3]}" R3_EVIDENCE="${evidences[R3]}" R3_LABEL="${labels[R3]}" \
+    R4_RESULT="${results[R4]}" R4_EVIDENCE="${evidences[R4]}" R4_LABEL="${labels[R4]}" \
+    R5_RESULT="${results[R5]}" R5_EVIDENCE="${evidences[R5]}" R5_LABEL="${labels[R5]}" \
+    VERDICT="$verdict" EXIT_CODE="$exit_code" \
+    node --input-type=module -e '
+        const rules = {
+            R1: { id: "R1", label: process.env.R1_LABEL, result: process.env.R1_RESULT, evidence: process.env.R1_EVIDENCE },
+            R2: { id: "R2", label: process.env.R2_LABEL, result: process.env.R2_RESULT, evidence: process.env.R2_EVIDENCE },
+            R3: { id: "R3", label: process.env.R3_LABEL, result: process.env.R3_RESULT, evidence: process.env.R3_EVIDENCE },
+            R4: { id: "R4", label: process.env.R4_LABEL, result: process.env.R4_RESULT, evidence: process.env.R4_EVIDENCE },
+            R5: { id: "R5", label: process.env.R5_LABEL, result: process.env.R5_RESULT, evidence: process.env.R5_EVIDENCE }
+        };
+        const out = {
+            rules,
+            verdict: process.env.VERDICT,
+            ok: process.env.EXIT_CODE === "0"
+        };
+        console.log(JSON.stringify(out, null, 2));
+    '
+    exit "$exit_code"
+fi
+
+echo ""
+echo "# /tokenwar check"
+echo ""
+
+for rule_id in R1 R2 R3 R4 R5; do
+    emit "${labels[$rule_id]}" "${results[$rule_id]}" "${evidences[$rule_id]}"
 done
 
 echo ""

--- a/scripts/gain.sh
+++ b/scripts/gain.sh
@@ -47,6 +47,14 @@ readonly COL_BOLD=$'\033[1m'
 readonly COL_DIM=$'\033[2m'
 readonly COL_RESET=$'\033[0m'
 
+json_mode=false
+for arg in "$@"; do
+    case "$arg" in
+        --json) json_mode=true ;;
+        *) echo "unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
 # === RTK ===
 # Returns: human-readable saved | note | numeric tokens saved
 rtk_summary() {
@@ -174,7 +182,150 @@ pxpipe_summary() {
     ' 2>/dev/null || echo "N/A|pxpipe events log read failed|0"
 }
 
-# === render ===
+# === json mode ===
+if $json_mode; then
+    # Gather per-tool summaries (reuse inline node blocks — just serialize)
+    rtk_s=$(rtk_summary); ctx_s=$(ctx_summary); mem_s=$(mem_summary)
+    caveman_s=$(caveman_summary); pxpipe_s=$(pxpipe_summary)
+
+    # Compute total tokens (sum numeric third field)
+    total_tokens=0
+    for s in "$rtk_s" "$ctx_s" "$mem_s" "$caveman_s" "$pxpipe_s"; do
+        t=$(echo "$s" | awk -F'|' '{print $3}')
+        total_tokens=$((total_tokens + ${t:-0}))
+    done
+    if (( total_tokens >= 1000000 )); then
+        total_human="$(awk -v t="$total_tokens" 'BEGIN{printf "%.1fM", t/1000000}')"
+    elif (( total_tokens >= 1000 )); then
+        total_human="$(awk -v t="$total_tokens" 'BEGIN{printf "%.1fK", t/1000}')"
+    else
+        total_human="$total_tokens"
+    fi
+
+    # Gather provider totals
+    provider_entries=""
+    for i in $(seq 0 $((PROVIDER_COUNT - 1))); do
+        pid=$(provider_id "$i")
+        pname=$(provider_name "$i")
+        raw=$(provider_telemetry_total "$i")
+        saved_p=""; note_p=""; tokens_p=""
+        IFS='|' read -r saved_p note_p tokens_p <<<"$raw"
+        tokens_p="${tokens_p:-0}"
+        entry=$(PID="$pid" PNAME="$pname" SAVED="$saved_p" NOTE="$note_p" TOKENS="$tokens_p" node --input-type=module -e '
+            const e = {
+                id: process.env.PID,
+                name: process.env.PNAME,
+                saved: process.env.SAVED,
+                saved_tokens: Number(process.env.TOKENS) || 0,
+                note: process.env.NOTE
+            };
+            console.log(JSON.stringify(e));
+        ')
+        if [[ -z "$provider_entries" ]]; then
+            provider_entries="$entry"
+        else
+            provider_entries="$provider_entries,$entry"
+        fi
+    done
+
+    # Gather monthly data (RTK + providers) if any
+    rtk_monthly_raw=""
+    if command -v "$RTK_BIN" >/dev/null 2>&1; then
+        rtk_monthly_raw="$("$RTK_BIN" gain --monthly 2>/dev/null || true)"
+    fi
+    rtk_has_monthly=false
+    if [[ -n "$rtk_monthly_raw" ]] && grep -qE "$MONTH_ROW_RE" <<<"$rtk_monthly_raw"; then
+        rtk_has_monthly=true
+    fi
+    # Build monthly JSON via node (parse same way as text mode)
+    monthly_json="{}"
+    if $rtk_has_monthly; then
+        # Use node to parse monthly rows into JSON array
+        rtk_monthly_json=$(RTK_MONTHLY="$rtk_monthly_raw" CLAUDE_IN="$CLAUDE_INPUT_USD_PER_MTOK" node --input-type=module -e '
+            const strip = s => s.replace(/\x1b\[[0-9;]*m/g, "");
+            const RE = /^(\d{4}-\d{2})\s+\S+\s+\S+\s+\S+\s+(\S+)/;
+            const toNum = h => { const m = String(h).trim().match(/^([\d.]+)\s*([KMGB]?)/i); if (!m) return 0; const u = (m[2]||"").toUpperCase(); return Math.round(parseFloat(m[1]) * ({K:1e3,M:1e6,G:1e9,B:1e9}[u]||1)); };
+            const CL = parseFloat(process.env.CLAUDE_IN);
+            const rows = [];
+            for (const ln of strip(process.env.RTK_MONTHLY||"").split("\n")) {
+                const m = ln.match(RE); if (!m) continue;
+                const tok = toNum(m[2]); if (!tok) continue;
+                rows.push({ month: m[1], saved: m[2], saved_tokens: tok, dollars: tok/1e6*CL });
+            }
+            console.log(JSON.stringify(rows));
+        ' 2>/dev/null || echo "[]")
+        monthly_json=$(echo "$rtk_monthly_json" | node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const rtk = JSON.parse(process.argv[1] || "[]");
+            console.log(JSON.stringify({ rtk }));
+        ' "$rtk_monthly_json" 2>/dev/null || echo '{"rtk":[]}')
+    fi
+    # Provider monthly: collect each provider’s monthly lines
+    provider_monthly_entries=""
+    for i in $(seq 0 $((PROVIDER_COUNT - 1))); do
+        mraw=$(provider_telemetry_monthly "$i")
+        [[ -z "$mraw" ]] && continue
+        pid=$(provider_id "$i")
+        # Convert "YYYY-MM tokens count" lines to JSON array via node
+        pj=$(PID="$pid" MRAW="$mraw" node --input-type=module -e '
+            const pid = process.env.PID;
+            const raw = process.env.MRAW || "";
+            const rows = [];
+            for (const ln of raw.trim().split("\n")) {
+                if (!ln.trim()) continue;
+                const parts = ln.trim().split(/\s+/);
+                if (parts.length < 2) continue;
+                rows.push({ month: parts[0], tokens: parseInt(parts[1],10)||0, sessions: parseInt(parts[2],10)||0 });
+            }
+            console.log(JSON.stringify({ id: pid, rows }));
+        ' 2>/dev/null)
+        if [[ -z "$pj" ]]; then
+            continue
+        fi
+        if [[ -z "$provider_monthly_entries" ]]; then
+            provider_monthly_entries="$pj"
+        else
+            provider_monthly_entries="$provider_monthly_entries,$pj"
+        fi
+    done
+    if [[ -n "$provider_monthly_entries" ]]; then
+        # Merge provider monthly into monthly_json (which may already contain rtk)
+        monthly_json=$(MONTHLY_JSON="$monthly_json" PROVIDER_MONTHLY="[$provider_monthly_entries]" node --input-type=module -e '
+            const base = JSON.parse(process.env.MONTHLY_JSON || "{}");
+            const prov = JSON.parse(process.env.PROVIDER_MONTHLY || "[]");
+            if (prov.length) base.providers = prov;
+            console.log(JSON.stringify(base));
+        ' 2>/dev/null || echo "$monthly_json")
+    fi
+
+    RTK_S="$rtk_s" CTX_S="$ctx_s" MEM_S="$mem_s" CAVEMAN_S="$caveman_s" PXPIPE_S="$pxpipe_s" \
+    TOTAL_TOKENS="$total_tokens" TOTAL_HUMAN="$total_human" \
+    PROVIDER_ENTRIES="[$provider_entries]" MONTHLY_JSON="$monthly_json" \
+    node --input-type=module -e '
+        const parse = s => {
+            const [saved, note, tokens] = s.split("|");
+            return { saved: saved || "N/A", saved_tokens: parseInt(tokens,10)||0, note: note || "" };
+        };
+        const tools = {
+            "RTK": parse(process.env.RTK_S),
+            "context-mode": parse(process.env.CTX_S),
+            "claude-mem": parse(process.env.MEM_S),
+            "caveman": parse(process.env.CAVEMAN_S),
+            "pxpipe": parse(process.env.PXPIPE_S)
+        };
+        // augment tools with tool name for easier assertions
+        const toolsList = Object.entries(tools).map(([tool, v]) => ({ tool, ...v }));
+        const total = { saved: process.env.TOTAL_HUMAN, saved_tokens: parseInt(process.env.TOTAL_TOKENS,10)||0 };
+        const providers = JSON.parse(process.env.PROVIDER_ENTRIES || "[]");
+        const monthly = JSON.parse(process.env.MONTHLY_JSON || "{}");
+        const out = { tools, tools_list: toolsList, total, providers };
+        if (Object.keys(monthly).length) out.monthly = monthly;
+        console.log(JSON.stringify(out, null, 2));
+    '
+    exit 0
+fi
+
+# === render (text mode) ===
 echo ""
 echo "${COL_BOLD}# /tokenwar gain — token savings${COL_RESET}"
 echo ""

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -47,9 +47,11 @@ readonly COL_YELLOW=$'\033[33m'
 readonly COL_RESET=$'\033[0m'
 
 test_mode=false
+json_mode=false
 for arg in "$@"; do
     case "$arg" in
         --test) test_mode=true ;;
+        --json) json_mode=true ;;
         *) echo "unknown arg: $arg" >&2; exit 2 ;;
     esac
 done
@@ -145,14 +147,7 @@ ping_ponytail() {
     [[ "$(plugin_state "$SLUG_PONY")" == "$STATUS_OK" ]]
 }
 
-# === report ===
-echo "# /tokenwar status"
-echo ""
-
-# ── Tools ──────────────────────────────────────────────────────────
-printf "  %s  %-14s  %-10s  %-22s  %s\n" "·" "tool" "version" "state" "note"
-printf "  ─────────────────────────────────────────────────────────────────\n"
-
+# === data gathering (shared by text and json modes) ===
 ctx_state=$(plugin_state "$SLUG_CTX");   ctx_ver=$(plugin_version "$SLUG_CTX")
 mem_state=$(plugin_state "$SLUG_MEM");   mem_ver=$(plugin_version "$SLUG_MEM")
 cave_state=$(plugin_state "$SLUG_CAVE"); cave_ver=$(plugin_version "$SLUG_CAVE")
@@ -169,6 +164,89 @@ if $test_mode; then
     ping_caveman    && cave_extra="ping=ok" || cave_extra="ping=FAIL"
     ping_ponytail   && pony_extra="ping=ok" || pony_extra="ping=FAIL"
 fi
+
+# ── JSON mode ──────────────────────────────────────────────────────
+if $json_mode; then
+    # Gather provider data for JSON
+    provider_json_entries=""
+    for i in $(seq 0 $((PROVIDER_COUNT - 1))); do
+        pid=$(provider_id "$i")
+        pname=$(provider_name "$i")
+        pver=$(provider_version "$i")
+        pstate=$(provider_state_str "$i")
+        case "$pid" in
+            claude) pnote="telemetry: RTK + ctx_stats + chroma-sync-state" ;;
+            codex)  pnote="telemetry: ~/.codex/state_5.sqlite (tokens_used)" ;;
+            gemini) pnote="telemetry: N/A (server-side sessions)" ;;
+            kimi)   pnote="telemetry: N/A (~/.kimi-code has no token store)" ;;
+            opencode) pnote="telemetry: ~/.local/share/opencode/opencode.db (session tokens)" ;;
+            *)      pnote="" ;;
+        esac
+        # Build JSON entry via node to ensure proper escaping
+        entry=$(PID="$pid" PNAME="$pname" PVER="$pver" PSTATE="$pstate" PNOTE="$pnote" node --input-type=module -e '
+            const e = {
+                id: process.env.PID,
+                name: process.env.PNAME,
+                version: process.env.PVER,
+                state: process.env.PSTATE,
+                note: process.env.PNOTE
+            };
+            console.log(JSON.stringify(e));
+        ')
+        if [[ -z "$provider_json_entries" ]]; then
+            provider_json_entries="$entry"
+        else
+            provider_json_entries="$provider_json_entries,$entry"
+        fi
+    done
+
+    # Determine overall ok (same logic as exit code)
+    tool_failures_json=0
+    for s in "$ctx_state" "$mem_state" "$cave_state" "$pony_state" "$rtk_st" "$pxpipe_st"; do
+        [[ "$s" == "$STATUS_OK" ]] || tool_failures_json=1
+    done
+    ok_json=$([[ $tool_failures_json -eq 0 ]] && echo "true" || echo "false")
+
+    CTX_STATE="$ctx_state" CTX_VER="$ctx_ver" CTX_EXTRA="$ctx_extra" \
+    MEM_STATE="$mem_state" MEM_VER="$mem_ver" MEM_EXTRA="$mem_extra" \
+    RTK_STATE="$rtk_st" RTK_VER="$rtk_ver" RTK_EXTRA="$rtk_extra" \
+    CAVE_STATE="$cave_state" CAVE_VER="$cave_ver" CAVE_EXTRA="$cave_extra" \
+    PONY_STATE="$pony_state" PONY_VER="$pony_ver" PONY_EXTRA="$pony_extra" \
+    PXPIPE_STATE="$pxpipe_st" PXPIPE_VER="$pxpipe_ver" PXPIPE_EXTRA="$pxpipe_extra" \
+    PROVIDER_ENTRIES="[$provider_json_entries]" OK_JSON="$ok_json" \
+    node --input-type=module -e '
+        const providers = JSON.parse(process.env.PROVIDER_ENTRIES);
+        const providersById = {};
+        for (const p of providers) providersById[p.id] = p;
+        const tools = {
+            "context-mode": { version: process.env.CTX_VER, state: process.env.CTX_STATE, note: process.env.CTX_EXTRA },
+            "claude-mem":   { version: process.env.MEM_VER, state: process.env.MEM_STATE, note: process.env.MEM_EXTRA },
+            "rtk":          { version: process.env.RTK_VER, state: process.env.RTK_STATE, note: process.env.RTK_EXTRA },
+            "caveman":      { version: process.env.CAVE_VER, state: process.env.CAVE_STATE, note: process.env.CAVE_EXTRA },
+            "ponytail":     { version: process.env.PONY_VER, state: process.env.PONY_STATE, note: process.env.PONY_EXTRA },
+            "pxpipe":       { version: process.env.PXPIPE_VER, state: process.env.PXPIPE_STATE, note: process.env.PXPIPE_EXTRA }
+        };
+        const out = {
+            tools,
+            providers: providersById,
+            ok: process.env.OK_JSON === "true"
+        };
+        console.log(JSON.stringify(out, null, 2));
+    '
+    # Exit with same code as text mode
+    if (( tool_failures_json )); then
+        exit 1
+    fi
+    exit 0
+fi
+
+# === report (text mode) ===
+echo "# /tokenwar status"
+echo ""
+
+# ── Tools ──────────────────────────────────────────────────────────
+printf "  %s  %-14s  %-10s  %-22s  %s\n" "·" "tool" "version" "state" "note"
+printf "  ─────────────────────────────────────────────────────────────────\n"
 
 format_line "context-mode" "$ctx_ver"  "$ctx_state"  "$ctx_extra"
 format_line "claude-mem"   "$mem_ver"  "$mem_state"  "$mem_extra"


### PR DESCRIPTION
## Résumé

Implémentation de la feature « Ajouter un mode sortie `--json` à status, gain et check » — « Ajouter un mode sortie `--json` à status, gain et check » dans hhallou/tokenwar.

## Fonctionnalités / modifications
Implémentation couvrant le périmètre de la feature « Ajouter un mode sortie `--json` à status, gain et check » (Ajouter un mode sortie `--json` à status, gain et check).
Travail effectué sur la branche `agent/feature-ajouter-un-mode-sortie-json` (base `main`),
avec un commit explicite par étape et un diff minimal.

## Tests réalisés
Aucun script de test détecté dans le dépôt :
les modifications reposent sur une vérification manuelle par l'agent.

## Références
feature « Ajouter un mode sortie `--json` à status, gain et check »