### PR TITLE
Feature: Étendre la règle R4 de `check.sh` aux 6 outils (ponytail et pxpipe ignorés)

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -147,12 +147,13 @@ check_r4() {
         return
     fi
     local missing=()
-    for slug in "context-mode@context-mode" "claude-mem@thedotmack" "caveman@caveman"; do
+    for slug in "context-mode@context-mode" "claude-mem@thedotmack" "caveman@caveman" "ponytail@ponytail"; do
         if ! grep -q "\"$slug\"" "$INSTALLED_PLUGINS"; then
             missing+=("$slug")
         fi
     done
     if command -v rtk >/dev/null 2>&1; then :; else missing+=("rtk"); fi
+    if command -v pxpipe >/dev/null 2>&1; then :; else missing+=("pxpipe"); fi
 
     if (( ${#missing[@]} == 0 )); then
         echo "$RES_PASS|core hook/plugin tools installed (latest-version check needs network; see /tokenwar upgrade)"


### PR DESCRIPTION
## Résumé

Implémentation de la feature « Étendre la règle R4 de `check.sh` aux 6 outils (ponytail et pxpipe ignorés) » — « Étendre la règle R4 de `check.sh` aux 6 outils (ponytail et pxpipe ignorés) » dans hhallou/tokenwar.

## Fonctionnalités / modifications
Implémentation couvrant le périmètre de la feature « Étendre la règle R4 de `check.sh` aux 6 outils (ponytail et pxpipe ignorés) » (Étendre la règle R4 de `check.sh` aux 6 outils (ponytail et pxpipe ignorés)).
Travail effectué sur la branche `agent/feature-etendre-la-regle-r4-de` (base `main`),
avec un commit explicite par étape et un diff minimal.

## Tests réalisés
Aucun script de test détecté dans le dépôt :
les modifications reposent sur une vérification manuelle par l'agent.

## Références
feature « Étendre la règle R4 de `check.sh` aux 6 outils (ponytail et pxpipe ignorés) »