### PR TITLE
Add local tokenwar scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Inside Claude Code (`/tokenwar <subcommand>`) or standalone (`bash ~/.claude/ski
 | --- | --- |
 | `/tokenwar status` | Health of the 6 tools — installed, enabled, version |
 | `/tokenwar gain` | Per-tool token savings + per-provider telemetry/status (Codex/Gemini/Kimi/opencode) + **monthly $ value** |
+| `/tokenwar scan` | Local agent-log scan that estimates which token-saving tools would have helped most |
 | `/tokenwar upgrade` | Bump each tool to latest (asks confirmation) |
 | `/tokenwar check` | Conflict detector — verifies the 6 tools stack additively |
 | `/tokenwar test` | End-to-end ping: is each tool actually working? |
@@ -145,6 +146,7 @@ in any shell:
 ```bash
 tokenwar status     # state of the 6 tools + providers
 tokenwar gain       # token savings + monthly $ value
+tokenwar scan       # local log scan + recommendations
 tokenwar upgrade    # bump managed tools (asks confirmation)
 tokenwar doctor     # status → check → gain
 tokenwar disable context-mode   # turn off one plugin without uninstalling it

--- a/docs/tokenwar-tools.md
+++ b/docs/tokenwar-tools.md
@@ -1,0 +1,72 @@
+# TokenWar Tool Map
+
+TokenWar should recommend tools by buffer, not by hype. A good scan asks:
+which part of the agent loop burned tokens, which tool owns that lane, and
+whether the host can install it safely.
+
+## Core Stack
+
+| Tool | Best At | Weakness | Use When | Avoid When | Telemetry |
+| --- | --- | --- | --- | --- | --- |
+| [RTK](https://github.com/rtk-ai/rtk) | Compressing shell/tool output before it enters agent context. | Only sees hooked shell commands; native file-read tools bypass it. | Logs show many `git`, `rg`, `find`, `sed`, `cat`, test, Docker, or `gh` calls. | The agent mostly uses non-shell structured tools or exact raw output is required by a parser. | Native `rtk gain` and monthly rows. |
+| [pxpipe](https://github.com/teamchong/pxpipe) | Shrinking provider-bound prompt/context payloads by rendering bulky text as image blocks. | Provider/model dependent; exact identifiers in images need a companion factsheet. | Long repeated prompts, generated docs, large structured payloads, or proxy-compatible Claude traffic. | The provider has weak/expensive vision support or exact text fidelity is more important than payload size. | Native `~/.pxpipe/events.jsonl` / `pxpipe stats`. |
+| [claude-mem](https://github.com/thedotmack/claude-mem) | Cross-session memory and compact recall. | Recall quality depends on write quality; can duplicate another memory layer if unmanaged. | Logs repeat project setup, rules, prior decisions, PR state, or "resume where we were" context. | One-shot work with no future session value. | Native state in `~/.claude-mem/chroma-sync-state.json`; token count is estimated per memory item. |
+| [caveman](https://github.com/JuliusBrussee/caveman) | Cutting verbose assistant prose. | Style-only; no native before/after byte telemetry. | The agent writes long explanations, status updates, reviews, or commit summaries. | User-facing prose needs normal tone, legal/medical nuance, or detailed teaching. | Presence only; scan can estimate opportunity from transcript volume, not actual savings. |
+| [ponytail](https://github.com/DietrichGebert/ponytail) | Smaller code and less abstraction. | Ruleset only; needs review discipline to avoid under-building. | Vibe coding, greenfield code, refactors, UI work, and repeated agent-authored diffs. | Protocol-heavy or compatibility-heavy code where explicit structure is required. | Presence only; savings compound through smaller future reads/diffs/reviews. |
+| [context-mode](https://github.com/mksglu/context-mode) | Sandboxed heavy data processing and FTS-backed recall. | MCP startup/tool latency, broader moving parts, and license review risk before bundling. | Huge files, HTTP responses, PDFs, scraped pages, or data that should be queried instead of pasted. | Fast local code lookup is the main need; prefer a lighter repo-map/code-search tool. | `ctx_stats` MCP data, injected into `gain.sh` as `CTX_STATS_JSON`. |
+
+## Knowledge And Navigation Tools
+
+These do not replace the six core lanes. They reduce exploration loops, which
+is often where agents quietly waste tokens before writing code.
+
+| Tool | Best At | Weakness | TokenWar Position |
+| --- | --- | --- | --- |
+| [Graphify](https://github.com/Graphify-Labs/graphify) | Local knowledge graph over code, docs, SQL, configs, and PDFs; queryable structure across a project. | Graph build step and project artifacts must stay scoped to repos that actually use it. | Recommend when logs show repeated cross-file discovery, architecture questions, or `rg/find/sed` sweeps. |
+| [OpenWiki](https://github.com/langchain-ai/openwiki) | Durable Markdown wiki maintained by an agent, good for onboarding and purpose memory. | It creates/maintains docs; it is not a live low-latency grep replacement. | Recommend when agents keep re-reading project rules, architecture, setup, and "why" context. |
+| [Serena](https://github.com/oraios/serena) | MCP-backed IDE-like symbol retrieval, reference lookup, refactoring, and debugging. | MCP dependency and language-server quality vary by repo/language. | Strong candidate when exact symbol navigation would replace many file reads. |
+| [Probe](https://github.com/probelabs/probe) | Code and Markdown context engine with AST parsing, semantic search, CLI, MCP, and SDK modes. | Smaller ecosystem than Serena; benchmark locally before defaulting. | Preferred context-mode alternative for code search because it offers direct CLI usage, not only MCP. |
+| [Stacklit](https://github.com/glincker/stacklit) | Compact repo map (`stacklit.json`) that agents can read instead of exploring. | Newer/smaller project; less semantic depth than IDE/LSP tools. | Good low-friction context-mode alternative for fast first-pass repo orientation. |
+| [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) | Native-binary knowledge graph with broad language coverage and very fast queries. | MCP tool, so still a process/tooling integration; verify claims and release trust before bundling. | Candidate for local-first structural memory when speed matters. |
+| [Argyph](https://github.com/ezzy1630/Argyph) | Local binary combining grep, symbol graph, semantic search, and repo packing. | Young project with limited adoption. | Watchlist; promising shape but not a default recommendation yet. |
+| [context-link](https://github.com/context-link-mcp/context-link) | Local MCP gateway using tree-sitter symbol/dependency context with token-savings metadata. | Young project; MCP-only surface. | Watchlist for users who want MCP but not context-mode. |
+| [Claude Context](https://github.com/zilliztech/claude-context) | Semantic code search over large codebases. | Requires external vector database and embedding API keys by default. | Not a default TokenWar recommendation for local-only scans. |
+
+## Recommendation Matrix
+
+| Log Signal | Recommend | Reason |
+| --- | --- | --- |
+| Many shell calls or huge command outputs | RTK | It owns `SHELL -> LLM` stdout compression. |
+| Repeated `rg/find/sed/cat/ls/git diff` exploration | Probe, Stacklit, Graphify, Serena | Replace multi-step discovery with maps, symbol lookup, or graph queries. |
+| Huge HTTP/file/PDF/scrape payloads | Probe for code, context-mode or context-link for sandboxed heavy data | Do not paste raw payloads into the transcript. Query/index them locally. |
+| Repeated project recap after session restarts | claude-mem and OpenWiki | Persist facts once, recall compactly later. |
+| Long assistant prose or long review comments | caveman | It targets `LLM -> USER` output. |
+| Lots of generated code, repeated refactors, large diffs | ponytail | Smaller code saves output now and input later. |
+| Long provider-bound prompts/context with proxy-compatible traffic | pxpipe | It attacks the provider API payload lane, separate from shell output. |
+
+## Current Context-Mode Stance
+
+Do not make context-mode the default replacement for every code-navigation
+case. It remains valuable for sandboxed heavy data and FTS-style offload, but
+for local code navigation TokenWar should test lighter alternatives first:
+
+1. Probe when a direct CLI/MCP code context engine is enough.
+2. Stacklit when a compact repo map should replace first-pass exploration.
+3. Serena when symbol-aware MCP/LSP navigation is worth the MCP overhead.
+4. Graphify when project structure and cross-document relationships matter.
+5. context-mode only when the workload is heavy data offload or sandboxed
+   content processing rather than normal repo search.
+
+## Scan Contract
+
+`tokenwar scan` is an opportunity estimator. It must never present estimated
+numbers as real savings.
+
+- Actual savings: only from native telemetry (`rtk gain`, `pxpipe stats`,
+  Codex/opencode token databases, `ctx_stats`).
+- Estimated opportunity: derived from local logs by matching command, search,
+  scrape, memory, verbosity, and code-generation signals.
+- Recommendation output must include both: `estimated avoidable tokens` and
+  the signal that caused the recommendation.
+- Default client selection should include installed/detected local clients, with
+  explicit `--client` / `--all` overrides for manual selection.

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+# tokenwar scan — local log opportunity estimator.
+#
+# This is not native telemetry. It reads local agent logs and estimates where
+# TokenWar tools could have reduced input/output pressure. Real savings remain
+# owned by `tokenwar gain`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+readonly DEFAULT_MAX_FILES=200
+readonly DEFAULT_MAX_BYTES_PER_FILE=524288
+readonly DEFAULT_MIN_RECOMMENDATION_TOKENS=1000
+readonly TOKEN_CHARS_PER_TOKEN=4
+readonly STATUS_SCRIPT="${SCRIPT_DIR}/status.sh"
+
+TOKENWAR_SCAN_MAX_FILES="${TOKENWAR_SCAN_MAX_FILES:-$DEFAULT_MAX_FILES}" \
+TOKENWAR_SCAN_MAX_BYTES_PER_FILE="${TOKENWAR_SCAN_MAX_BYTES_PER_FILE:-$DEFAULT_MAX_BYTES_PER_FILE}" \
+TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS="${TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS:-$DEFAULT_MIN_RECOMMENDATION_TOKENS}" \
+TOKENWAR_SCAN_CHARS_PER_TOKEN="$TOKEN_CHARS_PER_TOKEN" \
+TOKENWAR_STATUS_SCRIPT="$STATUS_SCRIPT" \
+node --input-type=module - "$@" <<'NODE'
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const CLIENTS = [
+  {
+    id: "claude",
+    name: "Claude Code",
+    cli: "claude",
+    roots: ["TOKENWAR_CLAUDE_LOG_ROOT", "~/.claude"],
+  },
+  {
+    id: "codex",
+    name: "Codex",
+    cli: "codex",
+    roots: ["TOKENWAR_CODEX_LOG_ROOT", "~/.codex"],
+  },
+  {
+    id: "gemini",
+    name: "Gemini CLI",
+    cli: "gemini",
+    roots: ["TOKENWAR_GEMINI_LOG_ROOT", "~/.gemini"],
+  },
+  {
+    id: "kimi",
+    name: "Kimi Code CLI",
+    cli: "kimi",
+    roots: ["TOKENWAR_KIMI_LOG_ROOT", "~/.kimi-code"],
+  },
+  {
+    id: "opencode",
+    name: "opencode",
+    cli: "opencode",
+    roots: ["TOKENWAR_OPENCODE_LOG_ROOT", "~/.local/share/opencode", "~/.config/opencode"],
+  },
+  {
+    id: "vibe",
+    name: "Vibe/Ora agents",
+    cli: "",
+    roots: ["TOKENWAR_VIBE_LOG_ROOT", "~/.ora/tasks", "~/.ora/contribute", "~/.claude/contributebg/logs"],
+  },
+  {
+    id: "cursor",
+    name: "Cursor",
+    cli: "cursor",
+    roots: ["TOKENWAR_CURSOR_LOG_ROOT", "~/.cursor"],
+  },
+];
+
+const LOG_EXTENSIONS = new Set([".jsonl", ".log", ".txt", ".md"]);
+const MAX_DEPTH = 5;
+const RTK_COMMAND_TOKEN_BUDGET = 900;
+const REPO_DISCOVERY_TOKEN_BUDGET = 700;
+const HEAVY_PAYLOAD_TOKEN_BUDGET = 1500;
+const MEMORY_TOKEN_BUDGET = 800;
+const CODE_GENERATION_TOKEN_BUDGET = 500;
+const PXPIPE_PAYLOAD_TOKEN_RATIO = 0.15;
+const CAVEMAN_OUTPUT_TOKEN_RATIO = 0.12;
+const TOTAL_TOKEN_RATIO_RTK_CAP = 0.45;
+const TOTAL_TOKEN_RATIO_REPO_CAP = 0.30;
+const TOTAL_TOKEN_RATIO_HEAVY_CAP = 0.35;
+const TOTAL_TOKEN_RATIO_MEMORY_CAP = 0.20;
+const TOTAL_TOKEN_RATIO_CODE_CAP = 0.10;
+const LONG_LINE_LENGTH = 2000;
+const LARGE_PAYLOAD_TOKENS = 50000;
+const DECISION_ENABLE = "ENABLE";
+const DECISION_KEEP = "KEEP";
+const DECISION_SKIP = "TOO MUCH";
+const DECISION_TRY = "TRY";
+
+const PATTERNS = {
+  shell: /\b(Bash|exec|shell|command|tool call|run command)\b/i,
+  command: /\b(git|gh|rg|grep|find|fd|sed|cat|head|tail|nl|awk|jq|curl|wget|docker|npm|pnpm|yarn|go|cargo|pytest|phpunit|composer|make|just|bats)\b/i,
+  search: /\b(rg|grep|find|fd|git grep|search_query)\b/i,
+  read: /\b(cat|sed -n|head|tail|nl -ba|readFile|Read tool|open\(|view file)\b/i,
+  http: /\b(curl|wget|gh api|gh pr view|web\.run|search_query|open\(|fetch|scrap|scrape|crawl)\b/i,
+  diff: /\b(git diff|gh pr diff|apply_patch|diff --git)\b/i,
+  test: /\b(go test|pytest|phpunit|bats|cargo test|npm test|pnpm test|yarn test|make test|shellcheck)\b/i,
+  memory: /\b(resume|previous session|context|summary|compaction|AGENTS\.md|coding-rules|SKILL\.md|neverdothis|where we were|red.?green)\b/i,
+  codeWrite: /\b(apply_patch|writeFile|cat >|tee .*<<|git commit|added [0-9]+ files?|insertions?\(|create mode)\b/i,
+  prose: /\b(assistant|codex|claude|summary|final answer|commentary|review|explain|analysis|resume)\b/i,
+};
+
+function usage() {
+  console.log(`tokenwar scan — local log opportunity estimator
+
+Usage:
+  tokenwar scan [--client ID ...] [--clients a,b] [--all] [--json]
+
+Clients:
+  ${CLIENTS.map((client) => client.id).join(", ")}
+
+Environment:
+  TOKENWAR_SCAN_MAX_FILES=${process.env.TOKENWAR_SCAN_MAX_FILES}
+  TOKENWAR_SCAN_MAX_BYTES_PER_FILE=${process.env.TOKENWAR_SCAN_MAX_BYTES_PER_FILE}
+  TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS=${process.env.TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS}
+  TOKENWAR_<CLIENT>_LOG_ROOT=/custom/path`);
+}
+
+function parseArgs(argv) {
+  const selected = new Set();
+  let all = false;
+  let json = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    }
+    if (arg === "--all") {
+      all = true;
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--client") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--client requires a value");
+      selected.add(value);
+      i += 1;
+      continue;
+    }
+    if (arg === "--clients") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--clients requires a value");
+      for (const id of value.split(",")) {
+        if (id.trim()) selected.add(id.trim());
+      }
+      i += 1;
+      continue;
+    }
+    throw new Error(`unknown arg: ${arg}`);
+  }
+  return { all, json, selected };
+}
+
+function expandHome(path) {
+  return path.startsWith("~/") ? join(homedir(), path.slice(2)) : path;
+}
+
+function rootPaths(client) {
+  const roots = [];
+  for (const item of client.roots) {
+    if (item.startsWith("TOKENWAR_")) {
+      const value = process.env[item];
+      if (value) roots.push(value);
+      continue;
+    }
+    roots.push(expandHome(item));
+  }
+  return [...new Set(roots)];
+}
+
+function hasCommand(command) {
+  if (!command) return false;
+  return spawnSync("sh", ["-lc", `command -v ${command}`], { stdio: "ignore" }).status === 0;
+}
+
+function fileExtension(path) {
+  const index = path.lastIndexOf(".");
+  return index === -1 ? "" : path.slice(index).toLowerCase();
+}
+
+function listLogFiles(root, maxFiles) {
+  if (!existsSync(root)) return [];
+  const files = [];
+  const stack = [{ path: root, depth: 0 }];
+  while (stack.length > 0 && files.length < maxFiles) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(current.path, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const path = join(current.path, entry.name);
+      if (entry.isDirectory()) {
+        if (current.depth < MAX_DEPTH && !entry.name.startsWith("node_modules")) {
+          stack.push({ path, depth: current.depth + 1 });
+        }
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (LOG_EXTENSIONS.has(fileExtension(entry.name))) files.push(path);
+      if (files.length >= maxFiles) break;
+    }
+  }
+  return files.sort((left, right) => {
+    try {
+      return statSync(right).mtimeMs - statSync(left).mtimeMs;
+    } catch {
+      return 0;
+    }
+  }).slice(0, maxFiles);
+}
+
+function readBounded(path, maxBytes) {
+  const data = readFileSync(path);
+  return data.length > maxBytes ? data.subarray(data.length - maxBytes).toString("utf8") : data.toString("utf8");
+}
+
+function emptyMetrics(client, roots, installed) {
+  return {
+    id: client.id,
+    name: client.name,
+    installed,
+    roots,
+    files: 0,
+    bytes: 0,
+    lines: 0,
+    estimated_tokens_seen: 0,
+    shell_hits: 0,
+    command_hits: 0,
+    search_hits: 0,
+    read_hits: 0,
+    http_hits: 0,
+    diff_hits: 0,
+    test_hits: 0,
+    memory_hits: 0,
+    code_write_hits: 0,
+    prose_hits: 0,
+    long_lines: 0,
+  };
+}
+
+function scanClient(client, maxFiles, maxBytesPerFile) {
+  const roots = rootPaths(client);
+  const installed = hasCommand(client.cli) || roots.some((root) => existsSync(root));
+  const metrics = emptyMetrics(client, roots.filter((root) => existsSync(root)), installed);
+  for (const root of roots) {
+    const files = listLogFiles(root, Math.max(0, maxFiles - metrics.files));
+    for (const file of files) {
+      let text;
+      try {
+        text = readBounded(file, maxBytesPerFile);
+      } catch {
+        continue;
+      }
+      metrics.files += 1;
+      metrics.bytes += Buffer.byteLength(text);
+      const lines = text.split(/\r?\n/);
+      metrics.lines += lines.length;
+      for (const line of lines) {
+        if (line.length >= LONG_LINE_LENGTH) metrics.long_lines += 1;
+        if (PATTERNS.shell.test(line)) metrics.shell_hits += 1;
+        if (PATTERNS.command.test(line)) metrics.command_hits += 1;
+        if (PATTERNS.search.test(line)) metrics.search_hits += 1;
+        if (PATTERNS.read.test(line)) metrics.read_hits += 1;
+        if (PATTERNS.http.test(line)) metrics.http_hits += 1;
+        if (PATTERNS.diff.test(line)) metrics.diff_hits += 1;
+        if (PATTERNS.test.test(line)) metrics.test_hits += 1;
+        if (PATTERNS.memory.test(line)) metrics.memory_hits += 1;
+        if (PATTERNS.codeWrite.test(line)) metrics.code_write_hits += 1;
+        if (PATTERNS.prose.test(line)) metrics.prose_hits += 1;
+      }
+    }
+  }
+  metrics.estimated_tokens_seen = Math.ceil(metrics.bytes / Number(process.env.TOKENWAR_SCAN_CHARS_PER_TOKEN || "4"));
+  return metrics;
+}
+
+function estimate(capTokens, count, perHit) {
+  return Math.max(0, Math.round(Math.min(capTokens, count * perHit)));
+}
+
+function humanTokens(tokens) {
+  if (tokens >= 1000000) return `${(tokens / 1000000).toFixed(1)}M`;
+  if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}K`;
+  return String(tokens);
+}
+
+function loadStatus() {
+  if (process.env.TOKENWAR_SCAN_SKIP_STATUS === "1") return {};
+  try {
+    const out = execFileSync("bash", [process.env.TOKENWAR_STATUS_SCRIPT, "--json"], { encoding: "utf8" });
+    return JSON.parse(out);
+  } catch (error) {
+    const stdout = error?.stdout?.toString();
+    if (stdout) {
+      try {
+        return JSON.parse(stdout);
+      } catch {
+        return {};
+      }
+    }
+    return {};
+  }
+}
+
+function toolState(status, id) {
+  return status?.tools?.[id]?.state || "unknown";
+}
+
+function decisionFor(item) {
+  const minRecommendationTokens = Number(process.env.TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS);
+  if (item.estimated_tokens < minRecommendationTokens) return DECISION_SKIP;
+  if (item.tool === "context-mode alternative") return DECISION_TRY;
+  if (item.tool === "Probe / Stacklit / Serena / Graphify") return DECISION_TRY;
+  if (item.state === "OK") return DECISION_KEEP;
+  if (item.state === "installed-disabled") return DECISION_ENABLE;
+  if (item.state === "not-installed" || item.state === "unknown") return DECISION_TRY;
+  return DECISION_TRY;
+}
+
+function buildRecommendations(metricsList, status) {
+  const aggregate = metricsList.reduce((acc, item) => {
+    for (const key of Object.keys(acc)) acc[key] += item[key] || 0;
+    return acc;
+  }, {
+    estimated_tokens_seen: 0,
+    command_hits: 0,
+    search_hits: 0,
+    read_hits: 0,
+    http_hits: 0,
+    diff_hits: 0,
+    test_hits: 0,
+    memory_hits: 0,
+    code_write_hits: 0,
+    prose_hits: 0,
+    long_lines: 0,
+  });
+
+  const total = aggregate.estimated_tokens_seen;
+  const repoDiscoveryHits = aggregate.search_hits + aggregate.read_hits + aggregate.diff_hits;
+  const heavyPayloadHits = aggregate.http_hits + aggregate.long_lines;
+  const shellHits = aggregate.command_hits + aggregate.test_hits;
+  const recommendations = [
+    {
+      tool: "RTK",
+      state: toolState(status, "rtk"),
+      estimated_tokens: estimate(total * TOTAL_TOKEN_RATIO_RTK_CAP, shellHits, RTK_COMMAND_TOKEN_BUDGET),
+      signal: `${shellHits} shell/test command signals`,
+      action: "Keep RTK enabled; route noisy shell discovery through Bash or direct rtk commands.",
+    },
+    {
+      tool: "Probe / Stacklit / Serena / Graphify",
+      state: "candidate",
+      estimated_tokens: estimate(total * TOTAL_TOKEN_RATIO_REPO_CAP, repoDiscoveryHits, REPO_DISCOVERY_TOKEN_BUDGET),
+      signal: `${repoDiscoveryHits} repo discovery signals`,
+      action: "Use a repo-map/code-context layer before broad rg/find/sed sweeps.",
+    },
+    {
+      tool: "context-mode alternative",
+      state: toolState(status, "context-mode"),
+      estimated_tokens: estimate(total * TOTAL_TOKEN_RATIO_HEAVY_CAP, heavyPayloadHits, HEAVY_PAYLOAD_TOKEN_BUDGET),
+      signal: `${heavyPayloadHits} heavy payload or scrape signals`,
+      action: "Prefer Probe/Stacklit for code; reserve context-mode or context-link for sandboxed heavy data.",
+    },
+    {
+      tool: "claude-mem / OpenWiki",
+      state: toolState(status, "claude-mem"),
+      estimated_tokens: estimate(total * TOTAL_TOKEN_RATIO_MEMORY_CAP, aggregate.memory_hits, MEMORY_TOKEN_BUDGET),
+      signal: `${aggregate.memory_hits} repeated memory/context signals`,
+      action: "Persist project decisions and generated wiki pages so resumes read compact memory, not old logs.",
+    },
+    {
+      tool: "pxpipe",
+      state: toolState(status, "pxpipe"),
+      estimated_tokens: total >= LARGE_PAYLOAD_TOKENS ? Math.round(total * PXPIPE_PAYLOAD_TOKEN_RATIO) : estimate(total * PXPIPE_PAYLOAD_TOKEN_RATIO, aggregate.long_lines, HEAVY_PAYLOAD_TOKEN_BUDGET),
+      signal: `${humanTokens(total)} scanned log tokens, ${aggregate.long_lines} long-line payloads`,
+      action: "Use proxy-side payload compression when provider traffic contains large repeated text blocks.",
+    },
+    {
+      tool: "caveman",
+      state: toolState(status, "caveman"),
+      estimated_tokens: Math.round(total * CAVEMAN_OUTPUT_TOKEN_RATIO),
+      signal: `${aggregate.prose_hits} prose/review/summary signals`,
+      action: "Use terse response mode for status, reviews, and repetitive operational chatter.",
+    },
+    {
+      tool: "ponytail",
+      state: toolState(status, "ponytail"),
+      estimated_tokens: estimate(total * TOTAL_TOKEN_RATIO_CODE_CAP, aggregate.code_write_hits, CODE_GENERATION_TOKEN_BUDGET),
+      signal: `${aggregate.code_write_hits} code-generation or diff signals`,
+      action: "Use ponytail for vibe-coding and refactors; smaller code compounds on every future read.",
+    },
+  ];
+
+  const minRecommendationTokens = Number(process.env.TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS);
+  if (!Number.isInteger(minRecommendationTokens) || minRecommendationTokens < 0) {
+    throw new Error("TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS must be a non-negative integer");
+  }
+
+  return recommendations
+    .map((item) => ({ ...item, decision: decisionFor(item) }))
+    .sort((left, right) => right.estimated_tokens - left.estimated_tokens);
+}
+
+function printText(metricsList, recommendations) {
+  const toolColumnWidth = 42;
+  console.log("# /tokenwar scan");
+  console.log("");
+  console.log("Local log scan. Numbers below are estimated opportunity, not native savings.");
+  console.log("");
+  console.log("  client        files    scanned     est tokens   top signals");
+  console.log("  -------------------------------------------------------------");
+  for (const item of metricsList) {
+    const signals = [
+      item.command_hits ? `${item.command_hits} cmd` : "",
+      item.search_hits ? `${item.search_hits} search` : "",
+      item.read_hits ? `${item.read_hits} read` : "",
+      item.http_hits ? `${item.http_hits} web` : "",
+      item.code_write_hits ? `${item.code_write_hits} code` : "",
+    ].filter(Boolean).join(", ") || "none";
+    console.log(`  ${item.id.padEnd(12)}  ${String(item.files).padStart(5)}  ${humanTokens(item.bytes).padStart(9)}  ${humanTokens(item.estimated_tokens_seen).padStart(10)}   ${signals}`);
+  }
+  console.log("");
+  console.log("Recommendations");
+  console.log(`  ${"tool".padEnd(toolColumnWidth)} decision   est avoidable   state       why`);
+  console.log("  ----------------------------------------------------------------------------------------------------");
+  for (const item of recommendations) {
+    console.log(`  ${item.tool.padEnd(toolColumnWidth)} ${item.decision.padEnd(9)} ${humanTokens(item.estimated_tokens).padStart(12)}   ${item.state.padEnd(10)} ${item.signal}`);
+    console.log(`      ${item.action}`);
+  }
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const requestedIds = args.selected;
+  const unknown = [...requestedIds].filter((id) => !CLIENTS.some((client) => client.id === id));
+  if (unknown.length > 0) throw new Error(`unknown client(s): ${unknown.join(", ")}`);
+
+  const maxFiles = Number(process.env.TOKENWAR_SCAN_MAX_FILES);
+  const maxBytesPerFile = Number(process.env.TOKENWAR_SCAN_MAX_BYTES_PER_FILE);
+  if (!Number.isInteger(maxFiles) || maxFiles < 1) throw new Error("TOKENWAR_SCAN_MAX_FILES must be a positive integer");
+  if (!Number.isInteger(maxBytesPerFile) || maxBytesPerFile < 1) throw new Error("TOKENWAR_SCAN_MAX_BYTES_PER_FILE must be a positive integer");
+
+  const candidates = CLIENTS.map((client) => ({ client, roots: rootPaths(client) }));
+  let selectedClients;
+  if (args.all) {
+    selectedClients = CLIENTS;
+  } else if (requestedIds.size > 0) {
+    selectedClients = CLIENTS.filter((client) => requestedIds.has(client.id));
+  } else {
+    selectedClients = candidates
+      .filter(({ client, roots }) => hasCommand(client.cli) || roots.some((root) => existsSync(root)))
+      .map(({ client }) => client);
+  }
+
+  const metricsList = selectedClients.map((client) => scanClient(client, maxFiles, maxBytesPerFile));
+  const status = loadStatus();
+  const recommendations = buildRecommendations(metricsList, status);
+  if (args.json) {
+    console.log(JSON.stringify({ clients: metricsList, recommendations }, null, 2));
+  } else {
+    printText(metricsList, recommendations);
+  }
+} catch (error) {
+  console.error(`tokenwar scan: ${error.message}`);
+  process.exit(2);
+}
+NODE

--- a/scripts/tokenwar.sh
+++ b/scripts/tokenwar.sh
@@ -7,6 +7,7 @@
 #
 #   tokenwar status     # state of the 6 tools + providers
 #   tokenwar gain       # per-tool + per-provider token savings
+#   tokenwar scan       # local agent-log scan + recommendations
 #   tokenwar check      # complementarity / conflict detector
 #   tokenwar test       # end-to-end ping: is each tool actually working?
 #   tokenwar upgrade    # bump managed tools (asks confirmation)
@@ -32,6 +33,7 @@ Usage: tokenwar <command>
 Commands:
   status     state of the 6 tools + providers (codex, gemini, kimi, opencode)
   gain       per-tool + per-provider token savings + monthly \$ value
+  scan       scan local agent logs and recommend token-saving tools
   check      complementarity / conflict detector
   test       end-to-end ping: is each tool actually working?
   upgrade    bump managed tools to latest (asks confirmation)
@@ -49,6 +51,7 @@ shift || true
 case "$cmd" in
     status)  exec bash "${SCRIPT_DIR}/status.sh" "$@" ;;
     gain)    exec bash "${SCRIPT_DIR}/gain.sh" "$@" ;;
+    scan)    exec bash "${SCRIPT_DIR}/scan.sh" "$@" ;;
     check)   exec bash "${SCRIPT_DIR}/check.sh" "$@" ;;
     test)
         bash "${SCRIPT_DIR}/status.sh" --test "$@"

--- a/tests/check.bats
+++ b/tests/check.bats
@@ -65,14 +65,17 @@ EOF
 {"plugins":{
   "context-mode@context-mode":[{"version":"1.0.107"}],
   "claude-mem@thedotmack":[{"version":"12.1.4"}],
-  "caveman@caveman":[{"version":"abc"}]
+  "caveman@caveman":[{"version":"abc"}],
+  "ponytail@ponytail":[{"version":"4.2.0"}]
 }}
 EOF
-    # Provide rtk command so R4 doesn't fail
+    # Provide command stubs so R4 doesn't fail
     export PATH="$HOME/bin:$PATH"
     mkdir -p "$HOME/bin"
     echo '#!/usr/bin/env bash' > "$HOME/bin/rtk"
+    echo '#!/usr/bin/env bash' > "$HOME/bin/pxpipe"
     chmod +x "$HOME/bin/rtk"
+    chmod +x "$HOME/bin/pxpipe"
 
     run bash "$SCRIPT"
     [[ "$output" == *"COMPLEMENTARY"* ]]

--- a/tests/dispatcher.bats
+++ b/tests/dispatcher.bats
@@ -11,6 +11,7 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"status"* ]]
     [[ "$output" == *"gain"* ]]
+    [[ "$output" == *"scan"* ]]
     [[ "$output" == *"upgrade"* ]]
 }
 

--- a/tests/scan.bats
+++ b/tests/scan.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# Tests for scan.sh — local log opportunity estimator.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/scan.sh"
+    DISPATCHER="$BATS_TEST_DIRNAME/../scripts/tokenwar.sh"
+    [ -x "$SCRIPT" ] || skip "scan.sh not executable"
+
+    export HOME="$(mktemp -d)"
+    export TOKENWAR_SCAN_SKIP_STATUS=1
+    export TOKENWAR_SCAN_MAX_FILES=20
+    export TOKENWAR_SCAN_MAX_BYTES_PER_FILE=20000
+    export TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS=1
+}
+
+teardown() {
+    rm -rf "$HOME"
+}
+
+write_codex_log() {
+    mkdir -p "$HOME/.codex"
+    cat > "$HOME/.codex/history.jsonl" <<'EOF'
+{"text":"run rg --files then sed -n '1,220p' scripts/tokenwar.sh"}
+{"text":"gh api repos/example/project/pulls/1/comments --paginate"}
+{"text":"curl -fsSL https://example.test/large.json"}
+{"text":"apply_patch added 120 insertions and git diff showed a large generated file"}
+{"text":"resume the previous session, read AGENTS.md and coding-rules.md again"}
+EOF
+}
+
+@test "scan recommends shell, context, memory, and code tools from local logs" {
+    write_codex_log
+
+    run bash "$SCRIPT" --client codex
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"# /tokenwar scan"* ]]
+    [[ "$output" == *"decision"* ]]
+    [[ "$output" == *"RTK"* ]]
+    [[ "$output" == *"Probe / Stacklit / Serena / Graphify"* ]]
+    [[ "$output" == *"context-mode alternative"* ]]
+    [[ "$output" == *"claude-mem / OpenWiki"* ]]
+    [[ "$output" == *"ponytail"* ]]
+}
+
+@test "scan json mode emits clients and recommendations" {
+    write_codex_log
+
+    run bash "$SCRIPT" --client codex --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"clients"'* ]]
+    [[ "$output" == *'"id": "codex"'* ]]
+    [[ "$output" == *'"recommendations"'* ]]
+}
+
+@test "dispatcher routes scan subcommand" {
+    write_codex_log
+
+    run bash "$DISPATCHER" scan --client codex
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"# /tokenwar scan"* ]]
+}


### PR DESCRIPTION
## Summary

- add `tokenwar scan`, a local-only log scanner that estimates which TokenWar tools would have helped most
- add an English tool map covering the core stack, strengths, weaknesses, and context-mode alternatives
- document and test the new dispatcher subcommand
- update the complementary-check fixture so it reflects the current six-tool stack (`ponytail` and `pxpipe` included)

## Test verification (RED -> GREEN)

RED on `origin/main` with the new dispatcher test applied:

```text
not ok 4 help lists the commands
# `[[ "$output" == *"scan"* ]]` failed
```

GREEN on this branch, targeted scope plus the fixed check fixture:

```text
$ docker run --rm -v "$PWD:/repo" -w /repo node:20-bookworm bash -lc 'apt-get update >/dev/null && apt-get install -y --no-install-recommends bats shellcheck >/dev/null && shellcheck -S warning scripts/*.sh scripts/lib/*.sh && chmod +x scripts/*.sh && bats tests/check.bats tests/scan.bats tests/dispatcher.bats'
1..12
ok 1 R1 PASS
ok 2 R1 WARN
ok 3 R1 FAIL
ok 4 R2 PASS
ok 5 R3 always PASS
ok 6 Verdict COMPLEMENTARY when all PASS
ok 7 scan recommends shell, context, memory, and code tools from local logs
ok 8 scan json mode emits clients and recommendations
ok 9 dispatcher routes scan subcommand
ok 10 help lists the commands
ok 11 unknown command exits 2 with usage
ok 12 check subcommand runs the checker
```

Additional validation:

```text
$ bash -n scripts/scan.sh scripts/tokenwar.sh tests/scan.bats tests/dispatcher.bats
$ git diff --check
$ TOKENWAR_SCAN_MAX_FILES=50 TOKENWAR_SCAN_MAX_BYTES_PER_FILE=65536 bash scripts/tokenwar.sh scan --all
```

Note: a full local Docker `bats tests/` run in `node:20-bookworm` still fails in `tests/statusline.bats`, but the prior GitHub Actions run on this PR passed those statusline cases. The branch CI is the source of truth for that environment.