### PR TITLE
Document and apply tokenwar scan recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,46 +25,11 @@ Stack diagram: <https://studio.oratelecom.net/tokenwar/>
 | **pxpipe**       | Provider-bound prompt/context payloads | `LLM → proxy → PNG blocks → API` |
 | **ponytail**     | The code the LLM writes             | `LLM → CODE (recurs on read)`     |
 
-## Complementarity diagram
-
-```mermaid
-flowchart LR
-    USER([👤 User])
-    LLM{{🧠 LLM}}
-    SHELL[/💻 Shell · tools/]
-    SANDBOX[(🧪 Sandbox + FTS5)]
-    MEM[(💾 claude-mem store)]
-    PROXY[[🖼️ pxpipe proxy]]
-    CODE[/📄 Source on disk/]
-
-    USER -->|prompt| LLM
-    LLM -->|caveman ⤵ output compress| USER
-    LLM -->|tool calls| SHELL
-    SHELL -->|RTK ⤵ stdout compress| LLM
-    LLM -->|context-mode ⤵ offload heavy ops| SANDBOX
-    SANDBOX -->|FTS5 search results| LLM
-    LLM -.->|persist session| MEM
-    MEM -.->|recall on resume| LLM
-    LLM -->|pxpipe ⤵ text to PNG blocks| PROXY
-    PROXY -->|provider API payload| LLM
-    LLM ==>|ponytail ⤵ generate less code| CODE
-    CODE -.->|RECURS · every future read · review · diff · grep| LLM
-
-    classDef caveman fill:#fde68a,stroke:#b45309,color:#000;
-    classDef rtk fill:#bae6fd,stroke:#0369a1,color:#000;
-    classDef ctx fill:#bbf7d0,stroke:#15803d,color:#000;
-    classDef mem fill:#e9d5ff,stroke:#7e22ce,color:#000;
-    classDef pxpipe fill:#fed7aa,stroke:#c2410c,color:#000;
-    classDef pony fill:#fbcfe8,stroke:#be185d,color:#000;
-    class USER caveman
-    class SHELL rtk
-    class SANDBOX ctx
-    class MEM mem
-    class PROXY pxpipe
-    class CODE pony
-```
-
-Each tool acts on a **distinct buffer or lane** — no buffer is double-processed, so the gains stack additively. Five lanes save on the live conversation or provider request path; ponytail's lane saves on the artifact on disk (replayed on every future read via the dotted `CODE -.-> LLM` loop). Different shapes of saving, same stack.
+Each tool acts on a **distinct buffer or lane** — no buffer is double-processed,
+so the gains stack additively. Five lanes save on the live conversation or
+provider request path; ponytail's lane saves on the artifact on disk and recurs
+on every future read, review, diff, and grep. Different shapes of saving, same
+stack.
 
 ## Why we picked each one — and why all six
 
@@ -94,7 +59,7 @@ The lazy-senior-dev ruleset ([DietrichGebert/ponytail](https://github.com/Dietri
 
 ## Why complementary (not conflicting)
 
-The tokenwar `check.sh` script enforces 4 rules:
+The tokenwar `check.sh` script enforces 5 rules:
 
 | Rule | What it verifies                                                                   | Status                  |
 | ---- | ---------------------------------------------------------------------------------- | ----------------------- |
@@ -102,8 +67,12 @@ The tokenwar `check.sh` script enforces 4 rules:
 | R2   | `claude-mem` writes to `~/.claude-mem`, `context-mode` to `~/.claude/projects/...` | Disjoint storage sinks  |
 | R3   | RTK targets tool stdout; caveman targets LLM output                                | Disjoint buffers        |
 | R4   | Core hook/plugin tools installed at current versions                               | `claude plugin list`    |
+| R5   | Active providers use separate config directories                                   | Disjoint provider state |
 
-When all four PASS, the verdict is `COMPLEMENTARY`. ponytail isn't in the conflict table because it owns no hook, store, or output buffer — it only shapes what the model writes. pxpipe is tracked in `status`, `gain`, `updates`, and `upgrade`; it sits at the provider proxy boundary, separate from RTK's shell-output lane. Six tools, still zero overlap.
+When all five PASS, the verdict is `COMPLEMENTARY`. ponytail shapes what the
+model writes; pxpipe is tracked in `status`, `gain`, `updates`, and `upgrade`
+and sits at the provider proxy boundary, separate from RTK's shell-output lane.
+Six tools, still zero overlap.
 
 ## Commands
 
@@ -120,6 +89,72 @@ Inside Claude Code (`/tokenwar <subcommand>`) or standalone (`bash ~/.claude/ski
 | `/tokenwar doctor` | Full pipeline: status → test → check → gain |
 | `/tokenwar disable <tool>` | Turn off one plugin (`context-mode`/`claude-mem`/`caveman`/`ponytail`) without uninstalling it |
 | `/tokenwar enable <tool>` | Turn a disabled plugin back on |
+
+## Local log scan
+
+`tokenwar scan` is the recommendation layer. It reads local agent logs, detects
+which clients are present, and estimates which TokenWar tools would have helped
+most. It does **not** upload logs, call a provider, or present estimated numbers
+as real telemetry.
+
+```bash
+tokenwar scan                  # scan detected local clients
+tokenwar scan --all            # include every supported client
+tokenwar scan --client codex   # scan one client
+tokenwar scan --clients codex,vibe --json
+tokenwar scan --apply          # ask before applying ENABLE recommendations
+tokenwar scan --apply --yes    # apply ENABLE recommendations without prompting
+```
+
+Supported clients:
+
+| Client | Default local roots | Default selection | Notes |
+| --- | --- | --- | --- |
+| Claude Code | `~/.claude` | Yes, when CLI or logs exist | Best coverage for plugin state and TokenWar-native setup. |
+| Codex | `~/.codex` | Yes, when CLI or logs exist | Good shell, search, read, and prose signal from local state. |
+| Gemini CLI | `~/.gemini` | Yes, when CLI or logs exist | Scan can recommend tools even when native token telemetry is unavailable. |
+| Kimi Code CLI | `~/.kimi-code` | Yes, when CLI or logs exist | Local logs are scanned; token totals remain estimates. |
+| opencode | `~/.local/share/opencode`, `~/.config/opencode` | Yes, when CLI or logs exist | Combines well with native usage telemetry from `tokenwar gain`. |
+| Vibe/Ora agents | `~/.ora/tasks`, `~/.ora/contribute`, `~/.claude/contributebg/logs` | Yes, when logs exist | Covers background contribution and vibe-coding agent logs. |
+| Cursor | `~/.cursor` | Yes, when CLI or logs exist | Reports `none` when the directory exists but no supported logs are found. |
+
+Each root can be overridden without changing config:
+
+```bash
+TOKENWAR_CODEX_LOG_ROOT=/path/to/codex/logs tokenwar scan --client codex
+TOKENWAR_SCAN_MAX_FILES=50 TOKENWAR_SCAN_MAX_BYTES_PER_FILE=65536 tokenwar scan --all
+```
+
+The decision column is intentionally blunt:
+
+| Decision | Meaning |
+| --- | --- |
+| `KEEP` | The tool is already active or detected and the logs show useful signal. |
+| `ENABLE` | The tool is installed but disabled, and the scan found enough matching signal. |
+| `TRY` | The scan found opportunity, but TokenWar should benchmark or install a candidate first. |
+| `TOO MUCH` | The signal is too small for the operational cost right now. |
+
+Example from a local multi-agent scan:
+
+```text
+RTK                                  KEEP      270.2K  shell/test command signals
+context-mode alternative             TRY       210.1K  heavy payload or scrape signals
+Probe / Stacklit / Serena / Graphify TRY       180.1K  repo discovery signals
+claude-mem / OpenWiki                KEEP      120.1K  repeated memory/context signals
+pxpipe                               KEEP       90.1K  scanned log tokens and long-line payloads
+caveman                              ENABLE     72.0K  prose/review/summary signals
+ponytail                             KEEP       15.5K  code-generation or diff signals
+```
+
+That example means: keep RTK, claude-mem, pxpipe, and ponytail; enable caveman
+for operational chatter; test a lighter code-context layer before making
+context-mode the default for code navigation.
+
+`--apply` only applies direct TokenWar plugin toggles whose decision is
+`ENABLE`. Today that means enabling `caveman`, `claude-mem`, or `ponytail` when
+they are installed but disabled. It intentionally does not install new tools,
+change RTK hooks, remove pxpipe, or choose a code-context alternative for you.
+Those remain explicit setup decisions.
 
 ## Status in every CLI (Claude, Codex, Gemini, Kimi, opencode)
 

--- a/docs/tokenwar-tools.md
+++ b/docs/tokenwar-tools.md
@@ -44,6 +44,68 @@ is often where agents quietly waste tokens before writing code.
 | Lots of generated code, repeated refactors, large diffs | ponytail | Smaller code saves output now and input later. |
 | Long provider-bound prompts/context with proxy-compatible traffic | pxpipe | It attacks the provider API payload lane, separate from shell output. |
 
+## Scan Client Compatibility
+
+`tokenwar scan` is local-only. It scans bounded log files from detected clients
+and never calls an AI provider.
+
+| Client ID | Client | Default Roots | Compatibility |
+| --- | --- | --- | --- |
+| `claude` | Claude Code | `~/.claude` | Full local log scan plus TokenWar plugin state through `status.sh`. |
+| `codex` | Codex | `~/.codex` | Full local log scan; strong signal for shell, repo discovery, and prose-heavy sessions. |
+| `gemini` | Gemini CLI | `~/.gemini` | Full local log scan; recommendations still work even though native token telemetry is unavailable. |
+| `kimi` | Kimi Code CLI | `~/.kimi-code` | Full local log scan when files exist; totals remain estimates. |
+| `opencode` | opencode | `~/.local/share/opencode`, `~/.config/opencode` | Full local log scan; pair with `tokenwar gain` for native token telemetry. |
+| `vibe` | Vibe/Ora agents | `~/.ora/tasks`, `~/.ora/contribute`, `~/.claude/contributebg/logs` | Full local log scan for background contribution and vibe-coding sessions. |
+| `cursor` | Cursor | `~/.cursor` | Detected when installed; reports no opportunity when no supported log files are found. |
+
+Every client root has an override named `TOKENWAR_<CLIENT>_LOG_ROOT`, for
+example `TOKENWAR_CODEX_LOG_ROOT=/tmp/codex-logs tokenwar scan --client codex`.
+
+`tokenwar scan --apply` turns the scan into a guarded activation flow:
+
+1. Scan local logs and print the normal recommendation table.
+2. Keep only direct TokenWar plugin toggles with decision `ENABLE`.
+3. Ask for confirmation before changing anything.
+4. Run `tokenwar enable <tool>` for each confirmed plugin.
+
+`tokenwar scan --apply --yes` is the non-interactive equivalent when the caller
+has already approved the changes. `--apply` cannot be combined with `--json`,
+because applying changes is an interactive text flow.
+
+The apply path is deliberately narrow. It can enable `caveman`, `claude-mem`,
+and `ponytail` when they are installed but disabled. It does not install missing
+tools, edit RTK hooks, remove pxpipe, or pick a third-party code-context
+candidate automatically.
+
+## Decision Vocabulary
+
+| Decision | Meaning |
+| --- | --- |
+| `KEEP` | The tool is already healthy or active enough, and the logs show matching value. |
+| `ENABLE` | The tool is installed but disabled, and the scan found enough matching signal. |
+| `TRY` | The scan found opportunity, but the best next step is a benchmark or candidate install. |
+| `TOO MUCH` | The signal is too small to justify the operational overhead right now. |
+
+## Observed Local Scan
+
+A recent multi-agent local scan over Claude, Codex, Gemini, Kimi, opencode,
+Vibe/Ora agents, and Cursor produced this ordering:
+
+| Recommendation | Decision | Estimated Opportunity | Signal |
+| --- | --- | --- | --- |
+| RTK | `KEEP` | 270.2K | 2348 shell/test command signals. |
+| context-mode alternative | `TRY` | 210.1K | 266 heavy payload or scrape signals. |
+| Probe / Stacklit / Serena / Graphify | `TRY` | 180.1K | 607 repo discovery signals. |
+| claude-mem / OpenWiki | `KEEP` | 120.1K | 468 repeated memory/context signals. |
+| pxpipe | `KEEP` | 90.1K | 600.4K scanned log tokens and 18 long-line payloads. |
+| caveman | `ENABLE` | 72.0K | 1389 prose/review/summary signals. |
+| ponytail | `KEEP` | 15.5K | 31 code-generation or diff signals. |
+
+The practical read: keep RTK, claude-mem, pxpipe, and ponytail; enable caveman
+for status/review chatter; test Probe or Stacklit before using context-mode as
+the default code-navigation path.
+
 ## Current Context-Mode Stance
 
 Do not make context-mode the default replacement for every code-navigation

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -14,13 +14,15 @@ readonly DEFAULT_MAX_FILES=200
 readonly DEFAULT_MAX_BYTES_PER_FILE=524288
 readonly DEFAULT_MIN_RECOMMENDATION_TOKENS=1000
 readonly TOKEN_CHARS_PER_TOKEN=4
-readonly STATUS_SCRIPT="${SCRIPT_DIR}/status.sh"
+readonly DEFAULT_STATUS_SCRIPT="${SCRIPT_DIR}/status.sh"
+readonly DEFAULT_TOGGLE_SCRIPT="${SCRIPT_DIR}/toggle.sh"
 
 TOKENWAR_SCAN_MAX_FILES="${TOKENWAR_SCAN_MAX_FILES:-$DEFAULT_MAX_FILES}" \
 TOKENWAR_SCAN_MAX_BYTES_PER_FILE="${TOKENWAR_SCAN_MAX_BYTES_PER_FILE:-$DEFAULT_MAX_BYTES_PER_FILE}" \
 TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS="${TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS:-$DEFAULT_MIN_RECOMMENDATION_TOKENS}" \
 TOKENWAR_SCAN_CHARS_PER_TOKEN="$TOKEN_CHARS_PER_TOKEN" \
-TOKENWAR_STATUS_SCRIPT="$STATUS_SCRIPT" \
+TOKENWAR_STATUS_SCRIPT="${TOKENWAR_STATUS_SCRIPT:-$DEFAULT_STATUS_SCRIPT}" \
+TOKENWAR_TOGGLE_SCRIPT="${TOKENWAR_TOGGLE_SCRIPT:-$DEFAULT_TOGGLE_SCRIPT}" \
 node --input-type=module - "$@" <<'NODE'
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
@@ -92,6 +94,14 @@ const DECISION_ENABLE = "ENABLE";
 const DECISION_KEEP = "KEEP";
 const DECISION_SKIP = "TOO MUCH";
 const DECISION_TRY = "TRY";
+const APPLY_ACTION_ENABLE = "enable";
+const APPLY_PROMPT = "Apply recommended TokenWar changes?";
+const APPLY_INPUT_PROMPT = "Apply? [y/N]";
+const APPLY_DECLINED_MESSAGE = "Apply skipped.";
+const APPLY_EMPTY_MESSAGE = "No directly applicable TokenWar changes found.";
+const APPLY_CONFIRM_ENV = "TOKENWAR_SCAN_CONFIRM";
+const APPLY_CONFIRM_COMMAND = "printf '%s ' \"$1\" > /dev/tty; IFS= read -r reply < /dev/tty; printf '%s' \"$reply\"";
+const YES_ANSWERS = new Set(["y", "yes"]);
 
 const PATTERNS = {
   shell: /\b(Bash|exec|shell|command|tool call|run command)\b/i,
@@ -111,6 +121,7 @@ function usage() {
 
 Usage:
   tokenwar scan [--client ID ...] [--clients a,b] [--all] [--json]
+  tokenwar scan --apply [--yes]
 
 Clients:
   ${CLIENTS.map((client) => client.id).join(", ")}
@@ -119,6 +130,7 @@ Environment:
   TOKENWAR_SCAN_MAX_FILES=${process.env.TOKENWAR_SCAN_MAX_FILES}
   TOKENWAR_SCAN_MAX_BYTES_PER_FILE=${process.env.TOKENWAR_SCAN_MAX_BYTES_PER_FILE}
   TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS=${process.env.TOKENWAR_SCAN_MIN_RECOMMENDATION_TOKENS}
+  TOKENWAR_TOGGLE_SCRIPT=${process.env.TOKENWAR_TOGGLE_SCRIPT}
   TOKENWAR_<CLIENT>_LOG_ROOT=/custom/path`);
 }
 
@@ -126,6 +138,8 @@ function parseArgs(argv) {
   const selected = new Set();
   let all = false;
   let json = false;
+  let apply = false;
+  let yes = false;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--help" || arg === "-h") {
@@ -138,6 +152,14 @@ function parseArgs(argv) {
     }
     if (arg === "--json") {
       json = true;
+      continue;
+    }
+    if (arg === "--apply") {
+      apply = true;
+      continue;
+    }
+    if (arg === "--yes" || arg === "-y") {
+      yes = true;
       continue;
     }
     if (arg === "--client") {
@@ -158,7 +180,8 @@ function parseArgs(argv) {
     }
     throw new Error(`unknown arg: ${arg}`);
   }
-  return { all, json, selected };
+  if (apply && json) throw new Error("--apply cannot be combined with --json");
+  return { all, apply, json, selected, yes };
 }
 
 function expandHome(path) {
@@ -376,6 +399,7 @@ function buildRecommendations(metricsList, status) {
     },
     {
       tool: "claude-mem / OpenWiki",
+      apply_tool: "claude-mem",
       state: toolState(status, "claude-mem"),
       estimated_tokens: estimate(total * TOTAL_TOKEN_RATIO_MEMORY_CAP, aggregate.memory_hits, MEMORY_TOKEN_BUDGET),
       signal: `${aggregate.memory_hits} repeated memory/context signals`,
@@ -390,6 +414,7 @@ function buildRecommendations(metricsList, status) {
     },
     {
       tool: "caveman",
+      apply_tool: "caveman",
       state: toolState(status, "caveman"),
       estimated_tokens: Math.round(total * CAVEMAN_OUTPUT_TOKEN_RATIO),
       signal: `${aggregate.prose_hits} prose/review/summary signals`,
@@ -397,6 +422,7 @@ function buildRecommendations(metricsList, status) {
     },
     {
       tool: "ponytail",
+      apply_tool: "ponytail",
       state: toolState(status, "ponytail"),
       estimated_tokens: estimate(total * TOTAL_TOKEN_RATIO_CODE_CAP, aggregate.code_write_hits, CODE_GENERATION_TOKEN_BUDGET),
       signal: `${aggregate.code_write_hits} code-generation or diff signals`,
@@ -442,6 +468,69 @@ function printText(metricsList, recommendations) {
   }
 }
 
+function buildApplyActions(recommendations) {
+  return recommendations
+    .filter((item) => item.decision === DECISION_ENABLE && item.apply_tool)
+    .map((item) => ({
+      label: `${APPLY_ACTION_ENABLE} ${item.apply_tool}`,
+      tool: item.apply_tool,
+      estimated_tokens: item.estimated_tokens,
+      signal: item.signal,
+    }));
+}
+
+function askYesNo() {
+  const configured = process.env[APPLY_CONFIRM_ENV];
+  if (configured) {
+    console.log(`${APPLY_INPUT_PROMPT} ${configured}`);
+    return YES_ANSWERS.has(configured.trim().toLowerCase());
+  }
+
+  const result = spawnSync("sh", ["-c", APPLY_CONFIRM_COMMAND, "sh", APPLY_INPUT_PROMPT], { encoding: "utf8" });
+  if (result.status !== 0) {
+    console.log(APPLY_INPUT_PROMPT);
+    return false;
+  }
+  return YES_ANSWERS.has(result.stdout.trim().toLowerCase());
+}
+
+function applyRecommendations(recommendations, yes) {
+  const actions = buildApplyActions(recommendations);
+  if (actions.length === 0) {
+    console.log(`\n${APPLY_EMPTY_MESSAGE}`);
+    return;
+  }
+
+  if (!yes) {
+    console.log(`\n${APPLY_PROMPT}`);
+    for (const action of actions) {
+      console.log(`  - ${action.label} (${humanTokens(action.estimated_tokens)} estimated opportunity; ${action.signal})`);
+    }
+  }
+
+  if (!yes && !askYesNo()) {
+    console.log(APPLY_DECLINED_MESSAGE);
+    return;
+  }
+
+  console.log("\nApplying recommended TokenWar changes");
+  for (const action of actions) {
+    try {
+      const output = execFileSync("bash", [process.env.TOKENWAR_TOGGLE_SCRIPT, APPLY_ACTION_ENABLE, action.tool], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const trimmed = output.trim();
+      if (trimmed) console.log(trimmed);
+    } catch (error) {
+      const stderr = error?.stderr?.toString().trim();
+      const stdout = error?.stdout?.toString().trim();
+      const detail = stderr || stdout || error.message;
+      throw new Error(`failed to ${action.label}: ${detail}`);
+    }
+  }
+}
+
 try {
   const args = parseArgs(process.argv.slice(2));
   const requestedIds = args.selected;
@@ -472,6 +561,7 @@ try {
     console.log(JSON.stringify({ clients: metricsList, recommendations }, null, 2));
   } else {
     printText(metricsList, recommendations);
+    if (args.apply) applyRecommendations(recommendations, args.yes);
   }
 } catch (error) {
   console.error(`tokenwar scan: ${error.message}`);

--- a/tests/scan.bats
+++ b/tests/scan.bats
@@ -28,6 +28,33 @@ write_codex_log() {
 EOF
 }
 
+write_apply_fixtures() {
+    cat > "$HOME/status.sh" <<'EOF'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "tools": {
+    "context-mode": {"state": "OK"},
+    "claude-mem": {"state": "OK"},
+    "rtk": {"state": "OK"},
+    "caveman": {"state": "installed-disabled"},
+    "ponytail": {"state": "OK"},
+    "pxpipe": {"state": "OK"}
+  }
+}
+JSON
+EOF
+    cat > "$HOME/toggle.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s %s\n' "$1" "$2" >> "$HOME/apply.log"
+printf 'enabled %s\n' "$2"
+EOF
+    chmod +x "$HOME/status.sh" "$HOME/toggle.sh"
+    export TOKENWAR_SCAN_SKIP_STATUS=0
+    export TOKENWAR_STATUS_SCRIPT="$HOME/status.sh"
+    export TOKENWAR_TOGGLE_SCRIPT="$HOME/toggle.sh"
+}
+
 @test "scan recommends shell, context, memory, and code tools from local logs" {
     write_codex_log
 
@@ -40,6 +67,49 @@ EOF
     [[ "$output" == *"context-mode alternative"* ]]
     [[ "$output" == *"claude-mem / OpenWiki"* ]]
     [[ "$output" == *"ponytail"* ]]
+}
+
+@test "scan apply asks before enabling applicable recommendations" {
+    write_codex_log
+    write_apply_fixtures
+
+    export TOKENWAR_SCAN_CONFIRM=yes
+    run bash "$SCRIPT" --client codex --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Apply recommended TokenWar changes?"* ]]
+    [[ "$output" == *"enable caveman"* ]]
+    [[ "$output" == *"enabled caveman"* ]]
+    [ "$(cat "$HOME/apply.log")" = "enable caveman" ]
+}
+
+@test "scan apply does nothing when declined" {
+    write_codex_log
+    write_apply_fixtures
+
+    export TOKENWAR_SCAN_CONFIRM=no
+    run bash "$SCRIPT" --client codex --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Apply skipped"* ]]
+    [ ! -f "$HOME/apply.log" ]
+}
+
+@test "scan apply yes flag enables without prompting" {
+    write_codex_log
+    write_apply_fixtures
+
+    run bash "$SCRIPT" --client codex --apply --yes
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Applying recommended TokenWar changes"* ]]
+    [[ "$output" != *"Apply recommended TokenWar changes?"* ]]
+    [ "$(cat "$HOME/apply.log")" = "enable caveman" ]
+}
+
+@test "scan apply refuses json mode" {
+    write_codex_log
+
+    run bash "$SCRIPT" --client codex --apply --json
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--apply cannot be combined with --json"* ]]
 }
 
 @test "scan json mode emits clients and recommendations" {


### PR DESCRIPTION
## Summary

- remove the old Mermaid complementarity diagram from the README while keeping the main stack image
- document `tokenwar scan` usage, supported clients, local log roots, env overrides, and decision labels
- add `tokenwar scan --apply`, a guarded activation flow for direct `ENABLE` recommendations
- keep the apply path intentionally narrow: it can enable installed-but-disabled `caveman`, `claude-mem`, and `ponytail`; it does not install new tools, edit RTK hooks, remove pxpipe, or choose third-party code-context tools
- add the observed local scan interpretation to the tool map and update the README check section from four rules to the current five-rule model

## Test verification (RED -> GREEN)

RED with the new `--apply` tests before implementation:

```text
not ok 2 scan apply asks before enabling applicable recommendations
not ok 3 scan apply does nothing when declined
not ok 4 scan apply yes flag enables without prompting
```

GREEN on this branch:

```text
$ docker run --rm -v "$PWD:/repo" -w /repo node:20-bookworm bash -lc 'apt-get update >/dev/null && apt-get install -y --no-install-recommends bats shellcheck >/dev/null && shellcheck -S warning scripts/*.sh scripts/lib/*.sh && chmod +x scripts/*.sh && bats tests/check.bats tests/scan.bats tests/dispatcher.bats'
1..16
ok 1 R1 PASS
ok 2 R1 WARN
ok 3 R1 FAIL
ok 4 R2 PASS
ok 5 R3 always PASS
ok 6 Verdict COMPLEMENTARY when all PASS
ok 7 scan recommends shell, context, memory, and code tools from local logs
ok 8 scan apply asks before enabling applicable recommendations
ok 9 scan apply does nothing when declined
ok 10 scan apply yes flag enables without prompting
ok 11 scan apply refuses json mode
ok 12 scan json mode emits clients and recommendations
ok 13 dispatcher routes scan subcommand
ok 14 help lists the commands
ok 15 unknown command exits 2 with usage
ok 16 check subcommand runs the checker
```

Additional validation:

```text
$ bash -n scripts/scan.sh
$ git diff --check
$ rg -n '[éèàçù]|GARDER|ACTIVER|TESTER|OPTIONNEL|Complementarity diagram|```mermaid|flowchart' README.md docs/tokenwar-tools.md scripts/scan.sh tests/scan.bats
# no matches
$ ORA_PROVIDER=codex bash scripts/tokenwar.sh scan --client codex --json | node -e '...'
scan json ok: 1 client(s), 7 recommendation(s)
$ TOKENWAR_SCAN_CONFIRM=no TOKENWAR_SCAN_MAX_FILES=50 TOKENWAR_SCAN_MAX_BYTES_PER_FILE=65536 ORA_PROVIDER=codex bash scripts/tokenwar.sh scan --client codex --apply
Apply recommended TokenWar changes?
  - enable caveman (14.2K estimated opportunity; 595 prose/review/summary signals)
Apply? [y/N] no
Apply skipped.
```