### PR TITLE
fix(launch): drop the interactive upgrade prompt from the provider banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,16 @@ wires it once:
 | CLI         | What you get                                                          |
 | ----------- | --------------------------------------------------------------------- |
 | Claude Code | Native persistent bottom bar (always visible)                         |
-| Codex       | Launch banner + `tokenwar status` reminder + inline upgrade prompt    |
-| Gemini CLI  | Launch banner + `tokenwar status` reminder + inline upgrade prompt    |
-| Kimi Code CLI | Launch banner + `tokenwar status` reminder + inline upgrade prompt  |
-| opencode    | Launch banner + `tokenwar status` reminder + inline upgrade prompt    |
+| Codex       | Launch banner + `tokenwar status` reminder + update status hint       |
+| Gemini CLI  | Launch banner + `tokenwar status` reminder + update status hint       |
+| Kimi Code CLI | Launch banner + `tokenwar status` reminder + update status hint     |
+| opencode    | Launch banner + `tokenwar status` reminder + update status hint       |
 
 After install you simply type `codex`, `gemini`, `kimi`, or `opencode` as usual —
-the banner prints, and if updates are pending you get **"⬆ N updates available.
-Upgrade now? [y/N]"** which bumps managed tools. A `tokenwar` command also works
-in any shell:
+the banner prints the stack bar. If updates are pending, the bar shows
+**"⬆ N updates · /tokenwar upgrade"** as an informational hint only; upgrades
+run only when you call `tokenwar upgrade` yourself. A `tokenwar` command also
+works in any shell:
 
 ```bash
 tokenwar status     # state of the 6 tools + providers

--- a/SKILL.md
+++ b/SKILL.md
@@ -46,10 +46,10 @@ context, never the screen. So tokenwar surfaces the stack differently per CLI:
 | CLI        | How the stack is surfaced                                              |
 | ---------- | --------------------------------------------------------------------- |
 | Claude Code | Native persistent bottom bar via `statusLine` (auto, always visible)  |
-| Codex      | **Launch banner** + reminder + upgrade prompt (via shell wrapper)     |
-| Gemini CLI | **Launch banner** + reminder + upgrade prompt (via shell wrapper)     |
-| Kimi Code CLI | **Launch banner** + reminder + upgrade prompt (via shell wrapper)  |
-| opencode   | **Launch banner** + reminder + upgrade prompt (via shell wrapper)     |
+| Codex      | **Launch banner** + reminder + update status hint (via shell wrapper) |
+| Gemini CLI | **Launch banner** + reminder + update status hint (via shell wrapper) |
+| Kimi Code CLI | **Launch banner** + reminder + update status hint (via shell wrapper) |
+| opencode   | **Launch banner** + reminder + update status hint (via shell wrapper) |
 
 `install.sh` wires the shell functions (one-time, then zero effort):
 
@@ -57,9 +57,9 @@ context, never the screen. So tokenwar surfaces the stack differently per CLI:
   `upgrade` work in **any** shell (Codex, Gemini, Kimi, opencode, plain terminal).
 - `codex` / `gemini` / `kimi` / `opencode` — wrapped so that launching any of
   them prints the tokenwar banner (`scripts/tokenwar-launch.sh`), reminds the
-  user to run `tokenwar status`, and — if the throttled cache shows pending
-  updates — offers an inline **"Upgrade now? [y/N]"** that runs
-  `scripts/upgrade.sh` for managed tools. The banner is silent for
+  user to run `tokenwar status`, and leaves pending updates as the statusline's
+  informational **"⬆ N updates · /tokenwar upgrade"** hint. It never runs
+  `scripts/upgrade.sh` automatically from provider launch. The banner is silent for
   non-interactive launches (`codex exec`, `gemini -p …`, `kimi -p …`,
   `opencode run …`, pipes) so it never pollutes scripted output.
 

--- a/scripts/tokenwar-launch.sh
+++ b/scripts/tokenwar-launch.sh
@@ -6,7 +6,7 @@
 # without touching their binaries is a one-time banner at launch:
 #   1. print the tokenwar stack bar (same renderer as the Claude statusline)
 #   2. remind the user that `tokenwar status` shows the full state on demand
-#   3. if updates are pending (from the throttled cache), offer to upgrade now
+#   3. leave upgrade drift as a statusline hint only
 #
 # This is intentionally non-blocking and silent for non-interactive launches
 # (`codex exec`, `gemini -p ...`, `kimi -p ...`, `opencode run ...`, pipes) so it never pollutes
@@ -25,10 +25,6 @@ shift || true
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
 readonly STATUSLINE_SCRIPT="${SCRIPT_DIR}/tokenwar-statusline.sh"
-readonly UPGRADE_SCRIPT="${SCRIPT_DIR}/upgrade.sh"
-readonly UPGRADE_CACHE_FILE="${HOME}/.claude/tokenwar/upgrade-check.json"
-readonly STATE_UPDATE="update-available"
-readonly UPGRADE_PROMPT_TIMEOUT_SECS=10
 
 readonly COL_DIM=$'\033[2m'
 readonly COL_YELLOW=$'\033[33m'
@@ -70,40 +66,5 @@ fi
 printf "%stokenwar%s · %s — run %stokenwar status%s for the full state · %stokenwar gain%s for token savings\n" \
     "$COL_YELLOW" "$COL_RESET" "$PROVIDER" \
     "$COL_DIM" "$COL_RESET" "$COL_DIM" "$COL_RESET"
-
-# 3. update offer — read the throttled cache only (no network here).
-update_count=0
-if [[ -f "$UPGRADE_CACHE_FILE" ]]; then
-    update_count=$(
-        CACHE="$UPGRADE_CACHE_FILE" TW_STATE="$STATE_UPDATE" node --input-type=module -e '
-            import { readFileSync } from "node:fs";
-            let d; try { d = JSON.parse(readFileSync(process.env.CACHE, "utf8")); } catch { console.log(0); process.exit(0); }
-            const buckets = [d.tools || {}];
-            let n = 0;
-            for (const b of buckets) for (const v of Object.values(b)) if (v && v.state === process.env.TW_STATE) n++;
-            console.log(n);
-        ' 2>/dev/null || echo 0
-    )
-fi
-update_count="${update_count:-0}"
-
-if (( update_count > 0 )); then
-    word="updates"; (( update_count == 1 )) && word="update"
-    printf "%s⬆ %d %s available.%s Upgrade now? [y/N] (auto-skip in %ds) " \
-        "$COL_YELLOW" "$update_count" "$word" "$COL_RESET" "$UPGRADE_PROMPT_TIMEOUT_SECS"
-    reply=""
-    if { : </dev/tty; } 2>/dev/null; then
-        read -r -t "$UPGRADE_PROMPT_TIMEOUT_SECS" reply </dev/tty 2>/dev/null || reply=""
-    fi
-    echo ""
-    case "$reply" in
-        y|Y|yes|YES)
-            if [[ -x "$UPGRADE_SCRIPT" ]]; then
-                bash "$UPGRADE_SCRIPT" --yes || true
-            fi
-            ;;
-        *) : ;;  # skip — banner is best-effort, never blocks the launch
-    esac
-fi
 
 exit 0

--- a/tests/launch.bats
+++ b/tests/launch.bats
@@ -59,3 +59,15 @@ EOF
     [[ "$output" != *"Upgrade now?"* ]]
     [[ "$output" != *"update available"* ]]
 }
+
+@test "interactive launch with pending tool update shows status hint without upgrade prompt" {
+    command -v script >/dev/null 2>&1 || skip "script command not available"
+    cat > "$HOME/.claude/tokenwar/upgrade-check.json" <<'EOF'
+{"tools":{"context-mode":{"state":"up-to-date"},"claude-mem":{"state":"up-to-date"},"caveman":{"state":"update-available"},"rtk":{"state":"up-to-date"},"pxpipe":{"state":"up-to-date"}},"providers":{"codex":{"state":"up-to-date"}}}
+EOF
+
+    run script -qfec "env HOME='$HOME' bash '$SCRIPT' codex" /dev/null
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/tokenwar upgrade"* ]]
+    [[ "$output" != *"Upgrade now?"* ]]
+}


### PR DESCRIPTION
## Problem

Launching a wrapped provider (`codex`, `gemini`, `kimi`, `opencode`) printed:

```
⬆ 1 update available. Upgrade now? [y/N] (auto-skip in 10s)
```

and blocked the TUI start for up to 10 seconds waiting on `/dev/tty`.

A launch wrapper is the wrong place to ask for consent — the user typed `codex`, not `tokenwar upgrade` — and an auto-skip timer that silently answers "no" is not consent either. It also made every provider launch feel like a nag loop.

## Change

`scripts/tokenwar-launch.sh` now only prints the stack bar plus the discoverability reminder. The bar already carries the informational hint rendered by `tokenwar-statusline.sh`:

```
[ctx 1.0.169] [mem 13.6.1] [rtk -] [caveman 766dce6 ⬆] [ponytail on] [pxpipe 0.10.0]  ⬆ 1 update · /tokenwar upgrade
tokenwar · codex — run tokenwar status for the full state · tokenwar gain for token savings
```

Upgrades run only when the user calls `tokenwar upgrade` themselves. That path keeps its own `[y/N]` confirmation in `scripts/upgrade.sh` — untouched here.

Docs updated in the same PR (`README.md`, `SKILL.md`): every "inline upgrade prompt" row in the per-CLI tables now reads "update status hint".

## Test verification (RED → GREEN)

New regression test `tests/launch.bats:64` drives the launcher under a real pty (`script -qfec`) with a cache that has one pending tool update, and asserts the hint is present while `Upgrade now?` is not.

**RED** — upstream `scripts/tokenwar-launch.sh` (stashed fix), new test applied:

```
1..8
ok 7 provider-only update cache does not offer managed upgrade
not ok 8 interactive launch with pending tool update shows status hint without upgrade prompt
# (in test file tests/launch.bats, line 72)
#   `[[ "$output" != *"Upgrade now?"* ]]' failed
```

**GREEN** — with the fix:

```
1..8
ok 8 interactive launch with pending tool update shows status hint without upgrade prompt
```

Full suite + linter on this branch:

```
121/121 bats tests pass
shellcheck -S warning scripts/*.sh scripts/lib/*.sh → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXot81hzCH5ViVyXJDwX4W